### PR TITLE
Fix: cc-lane OpenRouter exhaustion (402) now self-heals to Devin for dual-lane models

### DIFF
--- a/plugins/outsourcerer/skills/outsourcerer/SKILL.md
+++ b/plugins/outsourcerer/skills/outsourcerer/SKILL.md
@@ -162,6 +162,12 @@ reliable tool-using lane for GLM/open-weight models; **`devin`** fans out its ow
 **`codex`** is best for codex-native models (`sol`/`terra`/`gpt-5.5`). If you pick `codex` with an
 OpenRouter model and its upstream provider rejects Codex's native tool types, the skill **self-heals**
 by re-running that model on the `cc` lane automatically, fanout stays green no matter the provider.
+The same applies in reverse for dual-lane models (`glm` today): if `--provider cc`'s whole OpenRouter
+chain is exhausted on transport/availability grounds (out of credits, rate-limited, etc.), the skill
+self-heals across to that model's Devin sibling instead of dying, since it's the same model on a lane
+that isn't rationed by your OpenRouter balance. You don't need to pick `devin` up front to get that
+safety net, but if OpenRouter credits are already known to be tight, going straight to the default
+provider (`devin`, no `--provider` flag) skips the OpenRouter round-trip entirely.
 Full mechanics + the generic multi-agent recipe: `references/parallel-and-fanout.md`.
 
 ## Prerequisites

--- a/plugins/outsourcerer/skills/outsourcerer/references/parallel-and-fanout.md
+++ b/plugins/outsourcerer/skills/outsourcerer/references/parallel-and-fanout.md
@@ -94,6 +94,14 @@ dependent in Codex 0.144+), the skill automatically re-runs that model on the **
 standard Anthropic tool format every OpenRouter model serves. The job stays green; you just see a
 `>>> [self-heal]` line. So `fanout` is robust no matter which provider/model the user names.
 
+The same holds in the other direction for **dual-lane models** (`glm` today): if `--provider cc`'s
+whole OpenRouter chain is exhausted on transport/availability grounds (out of credits, rate-limited,
+provider down), the skill re-runs the SAME model on its **Devin** sibling instead of failing the job —
+Devin isn't rationed by your OpenRouter balance. You'll see a `>>> [self-heal]` line naming the Devin
+model it switched to. `OSRC_NO_CROSS_LANE=1` disables this if you specifically want a hard
+OpenRouter-only failure. If you already know OpenRouter credits are tight, skip the round-trip and
+fan out on the default provider (`devin`, no `--provider` flag) directly.
+
 ## Recipe: run a multi-agent SKILL (e.g. `<your-review-skill>`) through the Outsourcerer
 
 A gauntlet-style skill that launches many agent prompt files (`agents/*.md`) as native subagents can

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
@@ -2455,6 +2455,7 @@ _cloud_disclose() {
 
 delegate_cc() {
   local tier="$1"; shift
+  local ORIGARGS=("$@")   # preserved verbatim for the cross-lane self-heal (-> devin), same technique delegate_codex uses for -> cc
   _consume_flags "$@"
   [ "${#REST[@]}" -gt 0 ] || die "no task prompt given"
   local prompt="${REST[*]}"
@@ -2495,6 +2496,7 @@ delegate_cc() {
   local m rc=1 ttier wrapped cap
   local old_umask; old_umask="$(umask)"; umask 077
   cap="$OSRC_HOME/.ccerr-$$"
+  local last_transport=0
   for m in $(_or_chain "$tier"); do
     ttier="$(resolve_tier "$m" "")"
     wrapped="$(_build_prompt "$m" "$prompt" "")"
@@ -2510,21 +2512,46 @@ delegate_cc() {
       "ANTHROPIC_SMALL_FAST_MODEL=$m")
     [ -n "$think" ] && envp+=("MAX_THINKING_TOKENS=$think")
     local emode; emode="$(_perm_escalate "$mode" "$wrapped")"; [ "$emode" = REFUSE ] && die "$_perm_refuse_msg"
-    "${envp[@]}" claude -p ${bare[@]+"${bare[@]}"} ${sfx[@]+"${sfx[@]}"} ${CC_MCP_FLAGS[@]+"${CC_MCP_FLAGS[@]}"} ${tools[@]+"${tools[@]}"} --permission-mode "$emode" "$wrapped" 2>"$cap"
-    rc=$?
+    # Capture COMBINED stdout+stderr, like delegate_codex does (2>&1 | tee), not stderr-only.
+    # An OpenRouter transport/affordability error (e.g. "API Error: 402 ... requires more
+    # credits") is reported by `claude -p` as a stream-json/stdout message, NOT on stderr -- a
+    # stderr-only capture leaves _is_transport_failure permanently blind to it (verified live: a
+    # real 402 here produced empty/unrelated stderr -- just an "Advisor disabled" warning -- while
+    # the actual error only ever appeared in stdout). PIPESTATUS[0], not $?, after the pipe.
+    "${envp[@]}" claude -p ${bare[@]+"${bare[@]}"} ${sfx[@]+"${sfx[@]}"} ${CC_MCP_FLAGS[@]+"${CC_MCP_FLAGS[@]}"} ${tools[@]+"${tools[@]}"} --permission-mode "$emode" "$wrapped" 2>&1 | tee "$cap"
+    rc=${PIPESTATUS[0]}
     chmod 600 "$cap" 2>/dev/null || true
-    if [ "$rc" -eq 0 ]; then record_ledger cc "$m" "$ttier" "$tier" "$prompt"; break; fi
+    if [ "$rc" -eq 0 ]; then record_ledger cc "$m" "$ttier" "$tier" "$prompt"; last_transport=0; break; fi
     # Only escalate on transport/infra failures; task failures (red tests, max-turns, etc.) stop here.
     if _is_transport_failure "$(cat "$cap" 2>/dev/null)" "$rc"; then
+      last_transport=1
       echo "HINT: model '$m' failed (rc=$rc) on a transport/infra error; escalating to next in chain..." >&2
       continue
     fi
+    last_transport=0
     # Surface the task result to the orchestrator and stop retrying.
     cat "$cap" >&2
     break
   done
   rm -f "$cap" 2>/dev/null
   umask "$old_umask"
+  # Cross-lane self-heal: every model in the OpenRouter chain was exhausted on transport/
+  # availability grounds (e.g. 402 insufficient credit), and the ORIGINALLY requested model also
+  # has a Devin-lane sibling (glm today, see _devin_model_for). This is not a security downgrade
+  # (Devin has its own sandbox), so it heals by default -- opt out with OSRC_NO_CROSS_LANE=1 if
+  # you specifically want a hard OpenRouter-only failure (e.g. to test OpenRouter itself).
+  if [ "$rc" -ne 0 ] && [ "$last_transport" = "1" ] && [ "${OSRC_NO_CROSS_LANE:-0}" != "1" ]; then
+    local _dvm; _dvm="$(_devin_model_for "$MODEL")"
+    if [ -n "$_dvm" ]; then
+      printf '>>> [self-heal] OpenRouter exhausted for "%s" (transport/availability failure on every model tried); "%s" also runs on Devin -- retrying there instead. Set OSRC_NO_CROSS_LANE=1 to disable and fail on OpenRouter instead.\n' "$MODEL" "$_dvm" >&2
+      # Rewrite the model token in ORIGARGS so the Devin lane runs the Devin id, not the OR alias
+      # (same rewrite technique route_delegate's U6 reroute uses for the default-provider case).
+      local _i; for _i in "${!ORIGARGS[@]}"; do
+        case "${ORIGARGS[$_i]}" in -m|--model) [ $((_i+1)) -lt ${#ORIGARGS[@]} ] && ORIGARGS[$((_i+1))]="$_dvm" ;; esac
+      done
+      PROVIDER=devin delegate "$tier" "" ${ORIGARGS[@]+"${ORIGARGS[@]}"}; return $?
+    fi
+  fi
   return "$rc"
 }
 

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_cc_devin_selfheal.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_cc_devin_selfheal.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# test_cc_devin_selfheal.sh — cc-lane OpenRouter exhaustion (e.g. 402 insufficient credit) heals
+# across to the Devin lane for dual-lane models (glm today), instead of dying on OpenRouter with
+# a healthy Devin sibling sitting unused. Companion to the existing codex->cc self-heal
+# (test_no_silent_escalation.sh) and the default-provider U6 reroute (test_lane_fallback.sh).
+#
+# Root cause this guards: `claude -p` reports an OpenRouter transport/affordability error (e.g.
+# "API Error: 402 ... requires more credits") as a stream-json STDOUT message, not on stderr. A
+# stderr-only capture (delegate_cc's original `2>"$cap"`) leaves _is_transport_failure permanently
+# blind to it -- verified live against a real $0-credit OpenRouter key: stderr contained only an
+# unrelated "Advisor disabled" warning, never the actual 402. That silently turned every OpenRouter
+# credit exhaustion into an unretried, unescalated task failure.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SRC="$SCRIPT_DIR/../outsourcerer.sh"
+[ -f "$SRC" ] || { echo "FAIL: cannot find $SRC"; exit 1; }
+
+pass=0; fail=0
+ok()  { echo "PASS: $1"; pass=$((pass+1)); }
+bad() { echo "FAIL: $1"; fail=$((fail+1)); }
+
+# Extract + eval only the pure functions (avoid running main), same technique as test_lane_fallback.sh.
+eval "$(sed -n '/^_devin_model_for() {/,/^}/p' "$SRC")"
+eval "$(sed -n '/^_is_transport_failure() {/,/^}/p' "$SRC")"
+
+# --- Scenario 1: the real 402 string (captured from a live run against a $0-credit OpenRouter
+# key) IS classified as a transport failure -- this only matters once it can actually reach the
+# classifier, which is Scenario 2 below. ---
+real_402='API Error: 402 This request requires more credits, or fewer max_tokens. You requested up to 32000 tokens, but can only afford 9090. To increase, visit https://openrouter.ai/settings/credits and upgrade to a paid account'
+_is_transport_failure "$real_402" 1 && ok "_is_transport_failure classifies the real OpenRouter 402 string" || bad "real 402 string not classified as transport failure"
+
+# --- Scenario 2: delegate_cc captures COMBINED stdout+stderr (not stderr-only), so the 402 above
+# (a stdout/stream-json message, verified live) actually reaches _is_transport_failure. ---
+grep -q 'claude -p ${bare\[@\]+"${bare\[@\]}"} ${sfx\[@\]+"${sfx\[@\]}"} ${CC_MCP_FLAGS\[@\]+"${CC_MCP_FLAGS\[@\]}"} ${tools\[@\]+"${tools\[@\]}"} --permission-mode "$emode" "$wrapped" 2>&1 | tee "$cap"' "$SRC" \
+  && ok "delegate_cc captures combined stdout+stderr via 2>&1 | tee (not stderr-only)" \
+  || bad "delegate_cc still stderr-only captures (2>\"\$cap\"); OpenRouter 402s are stdout-only and invisible to _is_transport_failure"
+grep -q 'rc=${PIPESTATUS\[0\]}' "$SRC" && ok "delegate_cc reads rc via PIPESTATUS[0] after the pipe (not \$? of tee)" || bad "delegate_cc rc capture wrong after piping to tee"
+
+# --- Scenario 3: cross-lane self-heal is wired -- OpenRouter chain exhaustion for a dual-lane
+# model retries on Devin, gated by a transport-failure flag and an opt-out. ---
+grep -q 'last_transport=1' "$SRC" && ok "delegate_cc tracks a last_transport flag across the retry loop" || bad "last_transport flag missing"
+[ "$(grep -c '_devin_model_for "\$MODEL"' "$SRC")" -ge 2 ] && ok "_devin_model_for is consulted in >=2 places (U6 default-provider reroute + cc self-heal)" || bad "cc self-heal does not consult _devin_model_for"
+grep -q 'OSRC_NO_CROSS_LANE' "$SRC" && ok "cross-lane self-heal has an opt-out (OSRC_NO_CROSS_LANE)" || bad "no opt-out for cross-lane self-heal"
+grep -q 'PROVIDER=devin delegate "\$tier" "" \${ORIGARGS\[@\]+"\${ORIGARGS\[@\]}"}' "$SRC" && ok "self-heal re-dispatches to the Devin lane via ORIGARGS (preserves --effort/--with/etc.)" || bad "self-heal dispatch to devin missing or does not preserve original flags"
+
+# --- Scenario 4: ORIGARGS is captured before _consume_flags mutates state, and the model token
+# gets rewritten to the Devin id before re-dispatch (mirrors route_delegate's U6 rewrite). ---
+grep -q 'local ORIGARGS=("\$@")   # preserved verbatim for the cross-lane self-heal (-> devin)' "$SRC" && ok "delegate_cc preserves ORIGARGS before _consume_flags" || bad "ORIGARGS not preserved at top of delegate_cc"
+grep -q 'case "\${ORIGARGS\[\$_i\]}" in -m|--model) \[ \$((_i+1)) -lt \${#ORIGARGS\[@\]} \] && ORIGARGS\[\$((_i+1))\]="\$_dvm" ;; esac' "$SRC" && ok "self-heal rewrites the -m token in ORIGARGS to the Devin id" || bad "model-token rewrite in ORIGARGS missing"
+
+echo
+echo "RESULT: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What happened

I ran a `fanout` job (`--provider cc`, `-m glm`, 7 agents validating a review) with $0 OpenRouter
credits but Devin logged in and `glm-5.2` live and free there. Instead of falling back to Devin — the
same model, a lane the skill already knows about — the job just died on OpenRouter, and I had to
notice that myself and manually re-run with `--provider devin` to get it working.

That was surprising because the skill *already* has exactly this cross-lane awareness for the
**default** provider path (`_devin_model_for`, added for U6 — "use Devin's `glm-5.2` when OpenRouter
is out of quota"). It just doesn't apply once `--provider cc` is explicit, which is exactly what the
fanout recipe in `SKILL.md` / `references/parallel-and-fanout.md` recommends for GLM fanout work.

## Root cause (traced end-to-end, not guessed)

I dug into the actual job logs from that run before assuming anything:

```
$ cat ~/.outsourcerer/jobs/20260714-192849-ab41a41f0129/meta.json
{"provider":"cc","verb":"edit","model":"z-ai/glm-5.2","tier":"capable","lane":"or"}

$ grep -A2 402 ~/.outsourcerer/jobs/20260714-192849-ab41a41f0129/out.log
"API Error: 402 This request requires more credits, or fewer max_tokens.
You requested up to 32000 tokens, but can only afford 9090.
To increase, visit https://openrouter.ai/settings/credits and upgrade to a paid account"
```

So `delegate_cc` really did hit an OpenRouter affordability 402. `_is_transport_failure()` already has
a regex for exactly this (`api error:? *\(?[45][0-9][0-9]`), so I expected it to at least escalate
within the OpenRouter chain. It didn't. I reproduced the same call by hand against my (genuinely
$0-credit) OpenRouter key to see why:

```bash
env ANTHROPIC_BASE_URL="https://openrouter.ai/api" \
    ANTHROPIC_AUTH_TOKEN="$OPENROUTER_API_KEY" ANTHROPIC_API_KEY= \
    ANTHROPIC_MODEL="z-ai/glm-5.2" ANTHROPIC_SMALL_FAST_MODEL="z-ai/glm-5.2" \
    claude -p --bare --verbose --output-format stream-json --permission-mode default \
    "reply with the single word PONG and do nothing else" \
    1>stdout.log 2>stderr.log
echo $?          # -> 1
cat stderr.log    # -> only "Warning: Advisor disabled — base model 'z-ai/glm-5.2' has no advisor
                  #    rank in the model catalog. ..." — no mention of 402 anywhere
cat stdout.log    # -> the "API Error: 402 ..." text, inside the stream-json result message
```

`delegate_cc` captures **stderr only** (`2>"$cap"`), but `claude -p` reports an OpenRouter transport/
affordability error as a stream-json message on **stdout**. So `_is_transport_failure` never actually
sees the 402 — it sees an unrelated advisor warning, classifies it as an ordinary task failure, and
stops retrying right there. This isn't just a missing cross-lane fallback: it means the *existing*
within-chain escalation (`glm` → `hy3:free` → `deepseek`) is also blind to OpenRouter 402s today. It
happens not to bite most people because `hy3:free` (needs no credits) is first in the default chain —
but pass an explicit `-m glm`/`-m glm-5.2` (a single-model "chain") and there's nothing left to fall
through to.

`delegate_codex` already avoids this exact trap — it captures combined output (`2>&1 | tee "$cap"`,
`rc=${PIPESTATUS[0]}`). `delegate_cc` just never got the same treatment.

## The fix

1. **`delegate_cc`: capture combined stdout+stderr**, matching `delegate_codex`'s existing pattern
   (`2>&1 | tee "$cap"` + `rc=${PIPESTATUS[0]}`). No new regex needed — `_is_transport_failure`
   already classifies this 402 string correctly once it can actually see it.
2. **Cross-lane self-heal on chain exhaustion.** If every model in the OpenRouter chain fails on
   transport/availability grounds and the originally-requested model has a Devin sibling
   (`_devin_model_for`, the same helper the default-provider path already uses), retry on Devin
   instead of dying — same technique `delegate_codex`'s codex→cc self-heal already uses (preserve the
   original args in `ORIGARGS`, rewrite the model token, re-dispatch, print a `>>> [self-heal]`
   banner). Unlike the codex→cc heal, this isn't a sandbox downgrade (Devin has its own sandbox), so
   it's on by default; `OSRC_NO_CROSS_LANE=1` opts out for anyone who wants a hard OpenRouter-only
   failure (e.g. testing OpenRouter itself).
3. **Docs**: `SKILL.md` and `references/parallel-and-fanout.md` now say what actually happens when
   `--provider cc`'s OpenRouter chain is exhausted, instead of implying `cc` is a dead end for
   GLM/open-weight fanout work when credits run out.

## Testing

- Added `scripts/tests/test_cc_devin_selfheal.sh`: asserts (a) `_is_transport_failure` classifies the
  *actual* 402 string above as a transport failure, (b) `delegate_cc` now captures combined output
  instead of stderr-only, (c) the self-heal wiring (flag, opt-out, `ORIGARGS` preservation/rewrite,
  Devin re-dispatch) is present. I ran it against the pre-fix source too to confirm it fails there
  (7/9 red) and passes post-fix (9/9) — it's a real regression test, not just checking its own fix
  exists.
- Ran the full `scripts/tests/*.sh` suite before and after: identical pass/fail counts on both sides.
  The failures that exist (`test_autodetach.sh`, `test_hardening.sh`, etc.) are pre-existing and
  environmental — several tests `mkdir`/`touch` at filesystem root (`/jobs`, `/funcs.sh`,
  `/sab-home`, …), which isn't writable in my sandbox regardless of this change. Confirmed by diffing
  test output against an unmodified checkout of the same commit — byte-identical failure counts.
- What I could **not** test: the actual live Devin re-dispatch end-to-end (needs a real Devin session
  mid-fanout job), and whether `bg`/fanout's job-supervision layer wraps `delegate_cc`'s output in any
  way that would affect the combined-capture change. I traced the foreground path fully; the
  background/fanout path calls the same `delegate_cc`, but I'd appreciate your eyes on that if you
  have a faster way to exercise it than I do.

Scope note: `delegate_codex`'s own OpenRouter path (`-c model_provider=openrouter`) could plausibly
get the same cross-lane self-heal, but it already captures combined output correctly and wasn't what
broke for me, so I left it out to keep this diff focused on the actual incident.
