### PR TITLE
devin lane: surface sandboxed-proxy TLS failure diagnostics (0.4.11)

### DIFF
--- a/plugins/outsourcerer/CHANGELOG.md
+++ b/plugins/outsourcerer/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the Outsourcerer plugin are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [0.4.11] - 2026-07-18
+
+Diagnostics-only patch: when a devin-backed job dies on the sandboxed-proxy TLS mismatch (devin's Rust TLS stack rejecting a local proxy's cert), the failure is now recognizable from outsourcerer's side instead of a bare, generic "Connection error". No retry/routing/fallback behavior change.
+
+### Added
+- **Sandboxed-proxy TLS failure diagnostics for the devin lane.** devin prints only a generic "Connection error, send a message to continue retrying" when its `rustls_platform_verifier` rejects a local/sandboxed proxy's peer certificate (Apple Security `OSStatus -<n>` cert-verify code, visible only in devin's own CLI log at `~/.local/share/devin/cli/logs/`), silently retrying with backoff for ~100-160s before giving up. A narrow detector (`_is_sandboxed_proxy_tls_failure`, machine-token + corroborated two-pass, same false-positive discipline as `_is_transport_failure`) now scans devin's newest CLI log tail after a non-zero devin exit and surfaces a one-line hint naming the cause and the fix (disable the sandbox/proxy for that call). The hint flows through `delegate()` (foreground + bg, since the supervisor captures stderr into `out.log`) and is re-emitted by `result`/`logs` for a failed devin job when not already present. `doctor` proactively notes a `*_PROXY` env var when devin is installed. Diagnostics-only — no change to retry, routing, fallback, or transport-vs-task classification.
+
 ## [0.4.10] - 2026-07-16
 
 ### Changed

--- a/plugins/outsourcerer/skills/outsourcerer/references/jobs-and-safety.md
+++ b/plugins/outsourcerer/skills/outsourcerer/references/jobs-and-safety.md
@@ -52,6 +52,25 @@ show the user raw gate errors or make them learn flags; never blindly re-run a r
 and dies with the exact fix if not (sandboxed harness shells deny it: allow the path in the
 sandbox config, disable the sandbox for the call, or set `OSRC_HOME`). `doctor` reports it too.
 
+**Devin sandboxed-proxy TLS failure:** when a devin-backed job dies on the sandboxed-proxy TLS
+mismatch, devin prints only a bare `Connection error, send a message to continue retrying` and
+silently retries with backoff for ~100-160s before giving up. The real cause lives in devin's own
+CLI log (`~/.local/share/devin/cli/logs/devin_*.log`): `rustls_platform_verifier` rejecting a
+local/sandboxed proxy's peer certificate (`OSStatus -<n>` cert-verify code), typically alongside
+`chisel_cloud_bridge` handoff retries. outsourcerer scans the newest devin log tail after a
+non-zero devin exit and surfaces a one-line hint naming the cause and the fix:
+
+```
+devin TLS handshake failed against a local proxy in your shell (rustls cert verify: OSStatus -26276).
+This usually means a sandboxed/corporate proxy that devin's Rust TLS client won't trust. If you're
+inside Claude Code's sandboxed Bash tool, re-run this call with the sandbox disabled for devin-backed verbs.
+```
+
+This is diagnostics-only — it does not change retry, routing, fallback, or transport-vs-task
+classification. `doctor` proactively notes a `*_PROXY` env var when devin is installed. The hint
+flows through `delegate()` (foreground + bg, since the supervisor captures stderr into `out.log`)
+and is re-emitted by `result`/`logs` for a failed devin job when not already present.
+
 ## Windows (Git Bash, no WSL)
 
 `run`/`edit`/`yolo`/`bg`/`fanout`/`status`/`doctor`/`advise`/`consent` all work under Git Bash

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
@@ -2286,8 +2286,11 @@ cmd_result() {
   local id="${1:-}"; [ -n "$id" ] || die "result needs a job id"
   local jd="$OSRC_JOBS/$id"; [ -d "$jd" ] || die "no such job: $id"
   local shown rc=0
-  if [ -s "$jd/last.txt" ]; then shown="$(cat "$jd/last.txt")"; cat "$jd/last.txt" || rc=$?
-  else shown="$(tail -n 40 "$jd/out.log" 2>/dev/null)"; tail -n 40 "$jd/out.log" 2>/dev/null || rc=$?; fi
+  # Capture once and printf once (not cat+cat / tail+tail): a double read is a TOCTOU on a growing
+  # out.log and wastes IO. rc reflects the capture's status so a vanished file still surfaces nonzero.
+  if [ -s "$jd/last.txt" ]; then shown="$(cat "$jd/last.txt")" || rc=$?
+  else shown="$(tail -n 40 "$jd/out.log" 2>/dev/null)" || rc=$?; fi
+  printf '%s' "$shown"
   # Diagnostics-only: if this is a failed devin job and the recognizable TLS/proxy hint is not
   # already in the surfaced text, re-scan devin's own log and append it to STDERR (the cause lives
   # in ~/.local/share/devin/cli/logs/, not out.log; stderr keeps it out of the result payload).
@@ -2300,8 +2303,11 @@ cmd_result() {
 cmd_logs() {
   local id="${1:-}"; [ -n "$id" ] || die "logs needs a job id"
   local n=60; [ "${2:-}" = "-n" ] && n="${3:-60}"
+  # Capture once and printf once: a double tail is a TOCTOU on a growing log (the dedup check
+  # would see a different snapshot than what is printed). die fires on the capture if the log is
+  # missing; rc stays 0 on a successful print.
   local shown rc=0; shown="$(tail -n "$n" "$OSRC_JOBS/$id/out.log" 2>/dev/null)" || die "no log for $id"
-  tail -n "$n" "$OSRC_JOBS/$id/out.log" 2>/dev/null || rc=$?
+  printf '%s' "$shown"
   # Diagnostics-only (see cmd_result): append the recognizable TLS/proxy hint for a failed devin
   # job to STDERR when it is not already in the tailed log. `|| true` preserves the original
   # return code (rc) -- the helper's no-match exit must not change result/logs' exit status.

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
@@ -111,7 +111,7 @@ set -uo pipefail
 export PATH="$HOME/.local/bin:$PATH"
 # Version identifier (eng-plan-reviewer C1/H5). Single source of truth; bump the rightmost
 # number for patch releases. `doctor` and `--version` both read this.
-OSRC_VERSION="0.4.10"
+OSRC_VERSION="0.4.11"
 DEFAULT_MODEL="${OUTSOURCERER_MODEL:-glm-5.2}"
 
 # ---- platform detection (mac | linux | windows-gitbash). Windows = Git Bash / MSYS2, NO WSL
@@ -428,6 +428,11 @@ delegate() {
   if [ -n "$sandbox" ] && [ "$rc" -ne 0 ]; then
     echo "HINT: sandboxed run exited $rc. If a Read/Write scope was denied, retry with 'yolo' (dangerous, no sandbox)." >&2
   fi
+  # Diagnostics-only: devin prints a bare "Connection error" when its Rust TLS stack rejects a
+  # local/sandboxed proxy's cert (rustls OSStatus cert-verify, visible only in devin's own CLI log).
+  # Surface a specific, recognizable hint so the failure is diagnosable from outsourcerer's side.
+  # No retry/routing change -- the hint just names the cause and the fix (disable the sandbox/proxy).
+  [ "$rc" -ne 0 ] && _devin_sandboxed_proxy_tls_hint
   return "$rc"
 }
 
@@ -2278,13 +2283,23 @@ cmd_watch() {
 cmd_result() {
   local id="${1:-}"; [ -n "$id" ] || die "result needs a job id"
   local jd="$OSRC_JOBS/$id"; [ -d "$jd" ] || die "no such job: $id"
-  if [ -s "$jd/last.txt" ]; then cat "$jd/last.txt"; else tail -n 40 "$jd/out.log" 2>/dev/null; fi
+  local shown
+  if [ -s "$jd/last.txt" ]; then shown="$(cat "$jd/last.txt")"; cat "$jd/last.txt"; else shown="$(tail -n 40 "$jd/out.log" 2>/dev/null)"; tail -n 40 "$jd/out.log" 2>/dev/null; fi
+  # Diagnostics-only: if this is a failed devin job and the recognizable TLS/proxy hint is not
+  # already in the surfaced text, re-scan devin's own log and append it to STDERR (the cause lives
+  # in ~/.local/share/devin/cli/logs/, not out.log; stderr keeps it out of the result payload).
+  # No retry/routing change. stdout-only redirect: the hint itself is written to stderr by the helper.
+  _devin_job_tls_hint "$id" "$shown" >/dev/null
 }
 
 cmd_logs() {
   local id="${1:-}"; [ -n "$id" ] || die "logs needs a job id"
   local n=60; [ "${2:-}" = "-n" ] && n="${3:-60}"
-  tail -n "$n" "$OSRC_JOBS/$id/out.log" 2>/dev/null || die "no log for $id"
+  local shown; shown="$(tail -n "$n" "$OSRC_JOBS/$id/out.log" 2>/dev/null)" || die "no log for $id"
+  tail -n "$n" "$OSRC_JOBS/$id/out.log" 2>/dev/null
+  # Diagnostics-only (see cmd_result): append the recognizable TLS/proxy hint for a failed devin
+  # job to STDERR when it is not already in the tailed log. No retry/routing change.
+  _devin_job_tls_hint "$id" "$shown" >/dev/null
 }
 
 cmd_cancel() {
@@ -3885,6 +3900,77 @@ _is_transport_failure() {
   return 1
 }
 
+# _is_sandboxed_proxy_tls_failure <text> -> 0 if <text> carries the specific signature of devin's
+# Rust TLS stack (rustls_platform_verifier) rejecting a local/sandboxed proxy's peer certificate
+# (an Apple Security OSStatus cert-verify code), typically alongside chisel_cloud_bridge handoff
+# retries. This is the failure that surfaces from devin as a bare, generic "Connection error" with
+# no hint of the real cause; the signature only appears in devin's OWN CLI log
+# (~/.local/share/devin/cli/logs/), not in the captured out.log. DIAGNOSTICS-ONLY: this never
+# drives retry/routing/fallback -- it only names a recognizable failure so the caller can act.
+# Narrowness follows the same discipline as _is_transport_failure's PASS 1: the matched tokens are
+# MACHINE identifiers (a Rust crate name + an Apple Security error code) that never occur in
+# ordinary task/test prose, so an anywhere-in-text match is false-positive-safe.
+_is_sandboxed_proxy_tls_failure() {
+  local text="$1"
+  # PASS 1 (machine tokens, anywhere in text): rustls_platform_verifier + an OSStatus cert-verify
+  # code on the same log scan. Both tokens are emitted only by devin's TLS verify path against an
+  # untrusted peer cert and never appear in task/test output.
+  if printf '%s' "$text" | grep -qiE 'rustls_platform_verifier' && \
+     printf '%s' "$text" | grep -qiE 'OSStatus -[0-9]+'; then
+    return 0
+  fi
+  # PASS 2 (corroborated): chisel_cloud_bridge handoff retries + an OSStatus cert-verify code.
+  # The chisel tunnel is devin's cloud ACP transport; an OSStatus cert failure there is the same
+  # root cause surfaced through a different log line. Require BOTH tokens to stay narrow.
+  if printf '%s' "$text" | grep -qiE 'chisel_cloud_bridge' && \
+     printf '%s' "$text" | grep -qiE 'OSStatus -[0-9]+'; then
+    return 0
+  fi
+  return 1
+}
+
+# _devin_sandboxed_proxy_tls_hint -> 0 and prints a one-line diagnostics hint to stderr when
+# devin's own CLI log (~/.local/share/devin/cli/logs/devin_*.log) carries the sandboxed-proxy TLS
+# signature. Called from delegate() after a non-zero devin exit (covers foreground + bg: for bg the
+# supervisor captures stderr into out.log, so the hint reaches result/logs too). Purely diagnostic --
+# does not change retry/routing. Silent on no match. The scan reads only the tail of the NEWEST
+# devin log: the rustls/chisel retry storm lands at the end of the log right before devin gives up,
+# so a tail scan avoids stale matches from an earlier session (override tail size via
+# OSRC_DEVIN_LOG_SCAN, default 300 lines).
+_devin_sandboxed_proxy_tls_hint() {
+  local dlog_dir="${HOME}/.local/share/devin/cli/logs"
+  [ -d "$dlog_dir" ] || return 1
+  local newest; newest="$(ls -t "$dlog_dir"/devin_*.log 2>/dev/null | head -1)"
+  [ -n "$newest" ] || return 1
+  local tail_text; tail_text="$(tail -n "${OSRC_DEVIN_LOG_SCAN:-300}" "$newest" 2>/dev/null)"
+  [ -n "$tail_text" ] || return 1
+  _is_sandboxed_proxy_tls_failure "$tail_text" || return 1
+  local osstatus; osstatus="$(printf '%s' "$tail_text" | grep -oE 'OSStatus -[0-9]+' | head -1)"
+  [ -n "$osstatus" ] || osstatus="OSStatus cert-verify error"
+  printf 'devin TLS handshake failed against a local proxy in your shell (rustls cert verify: %s). This usually means a sandboxed/corporate proxy that devin'\''s Rust TLS client won'\''t trust. If you'\''re inside Claude Code'\''s sandboxed Bash tool, re-run this call with the sandbox disabled for devin-backed verbs.\n' "$osstatus" >&2
+  return 0
+}
+
+# _devin_job_tls_hint <job-id> <already-shown-text> -> emits the sandboxed-proxy TLS hint to stderr
+# for a terminal-failed devin job whose surfaced text does NOT already carry it (avoids
+# double-printing when delegate() already wrote the hint into out.log). Used by cmd_result/cmd_logs
+# so a caller inspecting a failed devin job later still sees the recognizable cause. Diagnostics-only.
+_devin_job_tls_hint() {
+  local id="$1" jd="$OSRC_JOBS/$1" shown="$2"
+  [ -d "$jd" ] || return 1
+  local prov; prov="$(_job_field "$id" '.provider' 2>/dev/null)"
+  [ "$prov" = "devin" ] || return 1
+  local st; st="$(cat "$jd/status" 2>/dev/null || echo '?')"
+  case "$st" in
+    failed|wedged|timeout|interrupted|permission-blocked) ;;
+    *) return 1 ;;
+  esac
+  case "$shown" in
+    *rustls*proxy*|*"devin TLS handshake failed"*) return 0 ;;   # already surfaced in out.log
+  esac
+  _devin_sandboxed_proxy_tls_hint
+}
+
 # delegate_codex <perm-tier> [-m MODEL] "<task>" , Codex exec -> OpenRouter (native Responses API)
 delegate_codex() {
   local tier="$1"; shift
@@ -4426,6 +4512,12 @@ doctor() {
     echo "  auth:  $(devin auth status 2>/dev/null | awk -F: '/Tier/{gsub(/^[ \t]+/,"",$2);print "logged in ("$2" tier)"}')"
   else
     echo "  auth:  NOT logged in -> run:  ! devin auth login"
+  fi
+  # Proactive diagnostics: a *_PROXY env var in this shell + devin present means devin's Rust TLS
+  # client may reject the proxy cert (rustls OSStatus cert-verify), surfacing as a bare "Connection
+  # error" ~100-160s in. Name it now so the failure is recognizable when it happens. Detect-only.
+  if [ -n "${HTTPS_PROXY:-}${HTTP_PROXY:-}${ALL_PROXY:-}${https_proxy:-}${http_proxy:-}${all_proxy:-}" ]; then
+    echo "  proxy: a *_PROXY env var is set in this shell — devin's Rust TLS client may reject the proxy cert (rustls OSStatus cert-verify error, surfaces as a bare 'Connection error' after ~100-160s). If devin-backed verbs fail that way, re-run with the sandbox/proxy disabled for that call."
   fi
   echo "  default model: $DEFAULT_MODEL"
   have jq   && echo "  jq:   $(jq --version 2>/dev/null) (needed for: jobs/status/advise/parity)" || echo "  jq:   not installed -> $( [ "$OSRC_PLATFORM" = "windows" ] && echo 'winget install jqlang.jq' || { [ "$OSRC_PLATFORM" = "mac" ] && echo 'brew install jq' || echo 'apt/dnf install jq'; }) (jobs/status/advise need it)"

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
@@ -432,7 +432,9 @@ delegate() {
   # local/sandboxed proxy's cert (rustls OSStatus cert-verify, visible only in devin's own CLI log).
   # Surface a specific, recognizable hint so the failure is diagnosable from outsourcerer's side.
   # No retry/routing change -- the hint just names the cause and the fix (disable the sandbox/proxy).
-  [ "$rc" -ne 0 ] && _devin_sandboxed_proxy_tls_hint
+  # `|| true` keeps the diagnostic line from leaking a non-zero status into delegate()'s return
+  # (rc is already captured above; the helper is best-effort and silent on no match).
+  [ "$rc" -ne 0 ] && _devin_sandboxed_proxy_tls_hint || true
   return "$rc"
 }
 
@@ -2283,23 +2285,28 @@ cmd_watch() {
 cmd_result() {
   local id="${1:-}"; [ -n "$id" ] || die "result needs a job id"
   local jd="$OSRC_JOBS/$id"; [ -d "$jd" ] || die "no such job: $id"
-  local shown
-  if [ -s "$jd/last.txt" ]; then shown="$(cat "$jd/last.txt")"; cat "$jd/last.txt"; else shown="$(tail -n 40 "$jd/out.log" 2>/dev/null)"; tail -n 40 "$jd/out.log" 2>/dev/null; fi
+  local shown rc=0
+  if [ -s "$jd/last.txt" ]; then shown="$(cat "$jd/last.txt")"; cat "$jd/last.txt" || rc=$?
+  else shown="$(tail -n 40 "$jd/out.log" 2>/dev/null)"; tail -n 40 "$jd/out.log" 2>/dev/null || rc=$?; fi
   # Diagnostics-only: if this is a failed devin job and the recognizable TLS/proxy hint is not
   # already in the surfaced text, re-scan devin's own log and append it to STDERR (the cause lives
   # in ~/.local/share/devin/cli/logs/, not out.log; stderr keeps it out of the result payload).
-  # No retry/routing change. stdout-only redirect: the hint itself is written to stderr by the helper.
-  _devin_job_tls_hint "$id" "$shown" >/dev/null
+  # No retry/routing change. `|| true` keeps the helper's no-match exit (1) from becoming this
+  # function's return code -- result/logs must stay 0 on a successful print (regression guard).
+  _devin_job_tls_hint "$id" "$shown" >/dev/null || true
+  return "$rc"
 }
 
 cmd_logs() {
   local id="${1:-}"; [ -n "$id" ] || die "logs needs a job id"
   local n=60; [ "${2:-}" = "-n" ] && n="${3:-60}"
-  local shown; shown="$(tail -n "$n" "$OSRC_JOBS/$id/out.log" 2>/dev/null)" || die "no log for $id"
-  tail -n "$n" "$OSRC_JOBS/$id/out.log" 2>/dev/null
+  local shown rc=0; shown="$(tail -n "$n" "$OSRC_JOBS/$id/out.log" 2>/dev/null)" || die "no log for $id"
+  tail -n "$n" "$OSRC_JOBS/$id/out.log" 2>/dev/null || rc=$?
   # Diagnostics-only (see cmd_result): append the recognizable TLS/proxy hint for a failed devin
-  # job to STDERR when it is not already in the tailed log. No retry/routing change.
-  _devin_job_tls_hint "$id" "$shown" >/dev/null
+  # job to STDERR when it is not already in the tailed log. `|| true` preserves the original
+  # return code (rc) -- the helper's no-match exit must not change result/logs' exit status.
+  _devin_job_tls_hint "$id" "$shown" >/dev/null || true
+  return "$rc"
 }
 
 cmd_cancel() {

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/conformance.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/conformance.sh
@@ -26,8 +26,8 @@ echo "=== STATIC gate: Phase-0 invariants wired ==="
 
 # 1. Every unit test suite is green (aggregate).
 for t in test_cloud_gate test_no_silent_escalation test_hardening test_escalation_classify \
-         test_lane_fallback test_interactive_default test_harness_isolation test_autodetach \
-         test_advise test_claudex test_copilot; do
+         test_devin_tls_diagnostics test_lane_fallback test_interactive_default \
+         test_harness_isolation test_autodetach test_advise test_claudex test_copilot; do
   if [ -f "$SCRIPT_DIR/$t.sh" ]; then
     if bash "$SCRIPT_DIR/$t.sh" >/dev/null 2>&1; then ok "unit suite $t green"; else bad "unit suite $t FAILED"; fi
   else note "unit suite $t absent"; fi

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_devin_tls_diagnostics.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_devin_tls_diagnostics.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# test_devin_tls_diagnostics.sh — devin sandboxed-proxy TLS failure diagnostics (additive, no
+# retry/routing change). Asserts the narrow detector fires on the rustls/OSStatus/chisel signature
+# in devin's own CLI log, does NOT false-positive on ordinary task/test output or the generic
+# "Connection error" devin prints, and that the hint surfaces through delegate()/result/logs
+# without double-printing and without touching _is_transport_failure's existing classifications.
+# Run: bash test_devin_tls_diagnostics.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SRC="$SCRIPT_DIR/../outsourcerer.sh"
+if [ ! -f "$SRC" ]; then echo FAIL: cannot find "$SRC"; exit 1; fi
+bash -n "$SRC" || { echo FAIL: bash -n failed for "$SRC"; exit 1; }
+
+TMP="$(mktemp -d)"
+export OSRC_HOME="$TMP"
+export HOME="$TMP"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+# Source the main script. main runs with no args and prints help (suppressed); functions stay defined.
+. "$SRC" >/dev/null 2>&1
+
+pass=0; fail=0
+ok()  { echo PASS: $1; pass=$((pass+1)); }
+bad() { echo FAIL: $1; fail=$((fail+1)); }
+
+# --- Scenario 1: _is_sandboxed_proxy_tls_failure unit classifications. ---
+# Positive: the exact signature from devin's own CLI log (rustls_platform_verifier + OSStatus).
+rustls_fixture='2026-07-18T22:14:02.103Z ERROR rustls_platform_verifier::verification::apple: failed to verify TLS certificate: invalid peer certificate: Other(OtherError("OSStatus -26276: -26276"))
+2026-07-18T22:14:02.104Z WARN  chisel_cloud_bridge::handoff: attempt=0 error=IO error: failed to lookup address information: nodename nor servname provided, or not known
+2026-07-18T22:14:03.105Z INFO  chisel_cloud_bridge::handoff: attempt=1 delay=1s [handoff] connect_acp: retrying'
+if _is_sandboxed_proxy_tls_failure "$rustls_fixture"; then ok "tls: rustls+OSStatus fixture detected"; else bad "tls: rustls+OSStatus fixture MISSED"; fi
+
+# Positive: a different OSStatus code (the broader OSStatus -[0-9]+ pattern, not just -26276).
+if _is_sandboxed_proxy_tls_failure 'ERROR rustls_platform_verifier::verification::apple: invalid peer certificate: Other(OtherError("OSStatus -26277: -26277"))'; then ok "tls: rustls+OSStatus -26277 detected"; else bad "tls: rustls+OSStatus -26277 MISSED"; fi
+
+# Positive: corroborated pass — chisel_cloud_bridge + OSStatus without the rustls token on the
+# matched scan (the same root cause surfaced through the chisel handoff log line).
+if _is_sandboxed_proxy_tls_failure 'INFO  chisel_cloud_bridge::handoff: attempt=3 delay=4s [handoff] connect_acp: retrying
+WARN  chisel: peer cert verify failed: OSStatus -26276'; then ok "tls: chisel+OSStatus corroborated detected"; else bad "tls: chisel+OSStatus corroborated MISSED"; fi
+
+# Negative: the GENERIC "Connection error" devin prints to its caller. This is the whole point —
+# the bare surfaced message must NOT be matched (it could mean anything); only the devin-log
+# signature is recognizable.
+generic_connection=(
+  'Error: Agent error: Connection error, send a message to continue retrying'
+  'Connection error, send a message to continue retrying'
+  'Connection error'
+  'connection refused'
+)
+for c in "${generic_connection[@]}"; do
+  if _is_sandboxed_proxy_tls_failure "$c"; then bad "tls: generic connection message FALSE-POSITIVE: '$c'"; else ok "tls: generic connection message not matched: '$c'"; fi
+done
+
+# Negative: ordinary task/test failures and unrelated network errors (already covered by
+# _is_transport_failure). The new detector must not fire on these — no behavior change.
+non_tls=(
+  'npm test failed'
+  'Tests failed'
+  'max-turns reached'
+  'some normal task error'
+  'HTTP 429: rate limit hit'
+  'connection timed out'
+  'curl: (6) Could not resolve host: openrouter.ai'
+  'model_not_found: unknown model'
+  'Authentication required: 401'
+  'the rustls crate is used by devin for TLS'                # prose mention of rustls, no OSStatus
+  'OSStatus is an Apple Security framework error code'      # prose mention of OSStatus, no rustls/chisel
+  'chisel is a tool for tunneling'                          # prose mention of chisel, no OSStatus
+)
+for c in "${non_tls[@]}"; do
+  if _is_sandboxed_proxy_tls_failure "$c"; then bad "tls: non-TLS FALSE-POSITIVE: '$c'"; else ok "tls: non-TLS not matched: '$c'"; fi
+done
+
+# Negative: empty text.
+if _is_sandboxed_proxy_tls_failure ""; then bad "tls: empty text FALSE-POSITIVE"; else ok "tls: empty text not matched"; fi
+
+# --- Scenario 2: _devin_sandboxed_proxy_tls_hint surfaces the hint from devin's own CLI log. ---
+# Build a fake HOME with a devin CLI log dir + a newest log carrying the signature at its tail.
+mkdir -p "$HOME/.local/share/devin/cli/logs"
+# An older log file (must NOT be scanned when a newer one exists — avoids stale matches).
+printf '%s\n' 'ERROR rustls_platform_verifier::verification::apple: OSStatus -9843 (stale, older session)' \
+  > "$HOME/.local/share/devin/cli/logs/devin_old.log"
+sleep 0.05 2>/dev/null || true
+# The newest log: the rustls/chisel retry storm at the tail (within the default 300-line scan).
+{
+  for i in $(seq 1 20); do printf '%s\n' "2026-07-18T22:13:0${i}Z INFO  devin: starting up (line $i)"; done
+  printf '%s\n' "$rustls_fixture"
+} > "$HOME/.local/share/devin/cli/logs/devin_newest.log"
+
+hint_out="$(_devin_sandboxed_proxy_tls_hint 2>&1)"
+if [ -n "$hint_out" ]; then ok "hint: emitted on signature in newest devin log"; else bad "hint: NOT emitted on signature"; fi
+if printf '%s' "$hint_out" | grep -q 'devin TLS handshake failed against a local proxy'; then ok "hint: names the cause"; else bad "hint: missing cause line"; fi
+if printf '%s' "$hint_out" | grep -q 'OSStatus -26276'; then ok "hint: carries the recognized OSStatus code"; else bad "hint: missing OSStatus code"; fi
+if printf '%s' "$hint_out" | grep -qi 'sandbox'; then ok "hint: names the fix (sandbox/proxy disabled)"; else bad "hint: missing fix"; fi
+# Must NOT surface the stale older-session code.
+if printf '%s' "$hint_out" | grep -q 'OSStatus -9843'; then bad "hint: FALSE-POSITIVE on stale older log (scanned the wrong file)"; else ok "hint: did not match stale older log"; fi
+
+# --- Scenario 2b: hint is silent when the devin log signature is absent. ---
+rm -f "$HOME/.local/share/devin/cli/logs"/devin_*.log
+printf '%s\n' '2026-07-18T22:15:00Z INFO  devin: normal run, no TLS error' \
+  > "$HOME/.local/share/devin/cli/logs/devin_clean.log"
+silent_out="$(_devin_sandboxed_proxy_tls_hint 2>&1)"
+if [ -n "$silent_out" ]; then bad "hint: FALSE-POSITIVE on clean devin log"; else ok "hint: silent on clean devin log"; fi
+
+# --- Scenario 2c: hint is silent when the devin log dir does not exist. ---
+rm -rf "$HOME/.local/share/devin"
+silent_out="$(_devin_sandboxed_proxy_tls_hint 2>&1)"
+if [ -n "$silent_out" ]; then bad "hint: FALSE-POSITIVE with no devin log dir"; else ok "hint: silent with no devin log dir"; fi
+
+# --- Scenario 3: _devin_job_tls_hint gates on provider + terminal state + dedup. ---
+# Re-create a devin log with the signature for the job-path scenarios.
+mkdir -p "$HOME/.local/share/devin/cli/logs"
+printf '%s\n' "$rustls_fixture" > "$HOME/.local/share/devin/cli/logs/devin_newest.log"
+mkdir -p "$OSRC_HOME/jobs"
+
+# 3a: failed devin job, hint not already in shown text -> emits.
+jid="job-devin-failed"
+jd="$OSRC_HOME/jobs/$jid"; mkdir -p "$jd"
+printf '{"provider":"devin","verb":"run","model":"glm-5.2"}' > "$jd/meta.json"
+echo failed > "$jd/status"
+job_hint="$(_devin_job_tls_hint "$jid" 'Error: Agent error: Connection error' 2>&1)"
+if [ -n "$job_hint" ]; then ok "job_hint: emits for failed devin job without hint in shown text"; else bad "job_hint: did NOT emit for failed devin job"; fi
+
+# 3b: hint already in shown text -> silent (no double-print).
+job_hint_dup="$(_devin_job_tls_hint "$jid" 'devin TLS handshake failed against a local proxy in your shell (rustls cert verify: OSStatus -26276).' 2>&1)"
+if [ -n "$job_hint_dup" ]; then bad "job_hint: DOUBLE-PRINTED when hint already in shown text"; else ok "job_hint: silent when hint already in shown text"; fi
+
+# 3c: non-devin provider -> silent (no false hint for a cc/codex job).
+jid2="job-cc-failed"; jd2="$OSRC_HOME/jobs/$jid2"; mkdir -p "$jd2"
+printf '{"provider":"cc","verb":"run","model":"glm-5.2"}' > "$jd2/meta.json"
+echo failed > "$jd2/status"
+job_hint_cc="$(_devin_job_tls_hint "$jid2" 'HTTP 429 rate limit' 2>&1)"
+if [ -n "$job_hint_cc" ]; then bad "job_hint: FALSE-POSITIVE for non-devin (cc) job"; else ok "job_hint: silent for non-devin (cc) job"; fi
+
+# 3d: devin job NOT in a terminal-failed state -> silent (running/done don't get the hint).
+jid3="job-devin-running"; jd3="$OSRC_HOME/jobs/$jid3"; mkdir -p "$jd3"
+printf '{"provider":"devin","verb":"run","model":"glm-5.2"}' > "$jd3/meta.json"
+echo running > "$jd3/status"
+job_hint_run="$(_devin_job_tls_hint "$jid3" 'some progress' 2>&1)"
+if [ -n "$job_hint_run" ]; then bad "job_hint: FALSE-POSITIVE for non-terminal (running) devin job"; else ok "job_hint: silent for non-terminal devin job"; fi
+
+# 3e: nonexistent job -> silent (no crash).
+job_hint_none="$(_devin_job_tls_hint "no-such-job" 'whatever' 2>&1)"
+if [ -n "$job_hint_none" ]; then bad "job_hint: emitted for nonexistent job"; else ok "job_hint: silent for nonexistent job"; fi
+
+# --- Scenario 4: regression — _is_transport_failure classifications are NOT affected. ---
+# The new diagnostics must not change existing transport-vs-task classification. Re-assert a few
+# canonical cases from test_escalation_classify.sh stay classified exactly as before.
+if _is_transport_failure 'HTTP 429: rate limit hit' 1; then ok "regression: 429 still transport"; else bad "regression: 429 no longer transport"; fi
+if _is_transport_failure 'connection refused' 1; then ok "regression: connection refused still transport"; else bad "regression: connection refused no longer transport"; fi
+if _is_transport_failure 'curl: (6) Could not resolve host: openrouter.ai' 1; then ok "regression: could not resolve host still transport"; else bad "regression: could not resolve host no longer transport"; fi
+if _is_transport_failure 'npm test failed' 1; then bad "regression: npm test falsely classified transport"; else ok "regression: npm test still NOT transport"; fi
+if _is_transport_failure 'max-turns reached' 1; then bad "regression: max-turns falsely classified transport"; else ok "regression: max-turns still NOT transport"; fi
+# The devin-log signature itself is NOT a transport failure (it is a diagnostics signal, not a
+# retry trigger) — asserting this keeps the diagnostics-only contract honest.
+if _is_transport_failure "$rustls_fixture" 1; then bad "regression: rustls signature leaked into _is_transport_failure (would change retry behavior)"; else ok "regression: rustls signature stays out of _is_transport_failure"; fi
+
+echo
+echo "RESULT: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_devin_tls_diagnostics.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_devin_tls_diagnostics.sh
@@ -145,6 +145,47 @@ if [ -n "$job_hint_run" ]; then bad "job_hint: FALSE-POSITIVE for non-terminal (
 job_hint_none="$(_devin_job_tls_hint "no-such-job" 'whatever' 2>&1)"
 if [ -n "$job_hint_none" ]; then bad "job_hint: emitted for nonexistent job"; else ok "job_hint: silent for nonexistent job"; fi
 
+# --- Scenario 3f: cmd_result/cmd_logs preserve exit 0 on a successful print (regression guard).
+# The diagnostics helper must NOT change result/logs' return code: a no-match helper exits 1, and
+# if it became the function's return code, `result`/`logs` would return non-zero on every successful
+# print. Re-emit-on-match must also leave the exit code at 0.
+# (a) devin job WITHOUT the TLS signature in devin's log -> hint silent, exit 0.
+rm -f "$HOME/.local/share/devin/cli/logs"/devin_*.log
+printf '%s\n' 'INFO  devin: normal run, no TLS error' > "$HOME/.local/share/devin/cli/logs/devin_clean.log"
+jid_clean="job-devin-clean"; jd_clean="$OSRC_HOME/jobs/$jid_clean"; mkdir -p "$jd_clean"
+printf '{"provider":"devin","verb":"run","model":"glm-5.2"}' > "$jd_clean/meta.json"
+echo done > "$jd_clean/status"
+printf 'all good, task complete\n' > "$jd_clean/last.txt"
+printf 'all good, task complete\n' > "$jd_clean/out.log"
+cmd_result "$jid_clean" >/dev/null 2>&1; rc_result=$?
+if [ "$rc_result" -eq 0 ]; then ok "cmd_result: exit 0 on successful print (no TLS match)"; else bad "cmd_result: exit $rc_result (regression: helper exit leaked)"; fi
+cmd_logs "$jid_clean" >/dev/null 2>&1; rc_logs=$?
+if [ "$rc_logs" -eq 0 ]; then ok "cmd_logs: exit 0 on successful print (no TLS match)"; else bad "cmd_logs: exit $rc_logs (regression: helper exit leaked)"; fi
+
+# (b) devin job WITH the TLS signature -> hint emitted to stderr, exit STILL 0.
+printf '%s\n' "$rustls_fixture" > "$HOME/.local/share/devin/cli/logs/devin_newest.log"
+jid_sig="job-devin-sig"; jd_sig="$OSRC_HOME/jobs/$jid_sig"; mkdir -p "$jd_sig"
+printf '{"provider":"devin","verb":"run","model":"glm-5.2"}' > "$jd_sig/meta.json"
+echo failed > "$jd_sig/status"
+printf 'Error: Agent error: Connection error\n' > "$jd_sig/last.txt"
+printf 'Error: Agent error: Connection error\n' > "$jd_sig/out.log"
+sig_out="$(cmd_result "$jid_sig" 2>/tmp/rr_sig 1>/dev/null)"; rc_sig=$?
+sig_err="$(cat /tmp/rr_sig 2>/dev/null)"; rm -f /tmp/rr_sig
+if [ "$rc_sig" -eq 0 ]; then ok "cmd_result: exit 0 even when hint is emitted"; else bad "cmd_result: exit $rc_sig when hint emitted (regression)"; fi
+if printf '%s' "$sig_err" | grep -q 'devin TLS handshake failed'; then ok "cmd_result: hint emitted to stderr on signature"; else bad "cmd_result: hint NOT emitted on signature"; fi
+sig_logs_out="$(cmd_logs "$jid_sig" 2>/tmp/rl_sig 1>/dev/null)"; rc_sigl=$?
+sig_logs_err="$(cat /tmp/rl_sig 2>/dev/null)"; rm -f /tmp/rl_sig
+if [ "$rc_sigl" -eq 0 ]; then ok "cmd_logs: exit 0 even when hint is emitted"; else bad "cmd_logs: exit $rc_sigl when hint emitted (regression)"; fi
+if printf '%s' "$sig_logs_err" | grep -q 'devin TLS handshake failed'; then ok "cmd_logs: hint emitted to stderr on signature"; else bad "cmd_logs: hint NOT emitted on signature"; fi
+
+# (c) non-devin (cc) job -> hint silent, exit 0.
+jid_cc="job-cc-clean"; jd_cc="$OSRC_HOME/jobs/$jid_cc"; mkdir -p "$jd_cc"
+printf '{"provider":"cc","verb":"run","model":"glm-5.2"}' > "$jd_cc/meta.json"
+echo done > "$jd_cc/status"
+printf 'result text\n' > "$jd_cc/last.txt"
+cc_err="$(cmd_result "$jid_cc" 2>&1 >/dev/null)"; rc_cc=$?
+if [ "$rc_cc" -eq 0 ] && [ -z "$cc_err" ]; then ok "cmd_result: non-devin job exit 0, no hint"; else bad "cmd_result: non-devin job rc=$rc_cc err='$cc_err'"; fi
+
 # --- Scenario 4: regression — _is_transport_failure classifications are NOT affected. ---
 # The new diagnostics must not change existing transport-vs-task classification. Re-assert a few
 # canonical cases from test_escalation_classify.sh stay classified exactly as before.

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_devin_tls_diagnostics.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_devin_tls_diagnostics.sh
@@ -82,7 +82,9 @@ mkdir -p "$HOME/.local/share/devin/cli/logs"
 # An older log file (must NOT be scanned when a newer one exists — avoids stale matches).
 printf '%s\n' 'ERROR rustls_platform_verifier::verification::apple: OSStatus -9843 (stale, older session)' \
   > "$HOME/.local/share/devin/cli/logs/devin_old.log"
-sleep 0.05 2>/dev/null || true
+# sleep 1 for deterministic mtime ordering on macOS (1s mtime granularity on HFS+; APFS is finer
+# but `ls -t` ties are still possible sub-second). Guarantees the newest log sorts strictly newer.
+sleep 1
 # The newest log: the rustls/chisel retry storm at the tail (within the default 300-line scan).
 {
   for i in $(seq 1 20); do printf '%s\n' "2026-07-18T22:13:0${i}Z INFO  devin: starting up (line $i)"; done


### PR DESCRIPTION
Hey Alex,

Ran into this tonight while grinding through a normal outsourcerer bg session on the free glm-5.2/Devin lane. Kept getting `Connection error, send a message to continue retrying` on `bg run` calls, no output, roughly 100-160s in, on completely trivial prompts too, so I knew it wasn't payload size or a slow task.

Chased it into devin's own CLI logs (`~/.local/share/devin/cli/logs/`) and found the real error hiding underneath:

```
ERROR rustls_platform_verifier::verification::apple: failed to verify TLS certificate: invalid peer certificate: Other(OtherError("OSStatus -26276: -26276"))
INFO  chisel_cloud_bridge::handoff: attempt=1 delay=1s [handoff] connect_acp: retrying
```

Turns out it's not outsourcerer, and it's not devin being flaky either. I run outsourcerer inside Claude Code's sandboxed Bash tool, which routes everything through a local proxy. Devin's `chisel_cloud_bridge` handoff goes through that proxy too, and devin's Rust TLS stack won't trust the proxy's cert, so it silently retries with backoff for a couple minutes before giving up and surfacing a generic `Connection error` with no hint of what actually happened. Confirmed it's the sandbox specifically: same call with the sandbox disabled works every time, no retries, no error.

I know outsourcerer can't fix the underlying TLS mismatch since that's entirely on the caller's sandbox setup, not something the script controls. But right now the failure is basically undiagnosable from outsourcerer's side, `Connection error` could mean anything. So this PR just makes the failure legible: when a devin job fails, scan for the known `rustls_platform_verifier`/`OSStatus`/`chisel_cloud_bridge` signature and surface a specific message pointing at the sandboxed-proxy TLS mismatch instead of the generic connection error, with the fix spelled out (disable the sandbox for that call). Same idea as the existing `state-home-not-writable` message, just for this failure mode. Added tests so it doesn't regress and doesn't false-positive on unrelated failures.

Happy to adjust scope or approach if you'd rather handle it differently - this is a narrow diagnostics-only change, no behavior change to the retry/fallback logic itself.
