### PR TITLE
Release v0.4.23: watcher cadence + green CI

### DIFF
--- a/plugins/outsourcerer/.claude-plugin/plugin.json
+++ b/plugins/outsourcerer/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "outsourcerer",
   "displayName": "Outsourcerer",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "description": "Delegate the grind, keep the glory. Offload grunt work to a cheaper or different engine (OpenRouter, Codex, keyless Gemini) while Claude orchestrates, or pull a stronger model in as an advisor. Per-model prompting, image gen, consensus second opinions, cost Tab.",
   "author": {
     "name": "Alex Greenshpun",

--- a/plugins/outsourcerer/CHANGELOG.md
+++ b/plugins/outsourcerer/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the Outsourcerer plugin are documented here.
 
+## 0.4.23
+
+- **Watcher now reports on a cadence.** `cmd_watch` emits a periodic `OSRC::PROGRESS` status digest
+  (state · last marker · elapsed · next) even when nothing changes, so a long silent-but-healthy run
+  no longer looks like a hang and the orchestrator can surface it into the running session without
+  being asked. Tunable via `OSRC_WATCH_DIGEST_SECS` (default 420s); a final digest fires on terminal
+  state. No new process or state file.
+- **Fix a real liveness bug:** `_devin_live_mtime` used a BSD-first `stat -f %m || stat -c %Y` probe
+  that returns garbage and exits 0 on GNU/Linux, so a LIVE devin job's heartbeat was ignored and the
+  watchdog killed it as `wedged`. Now reuses the hardened, portable `_mtime` helper.
+- **Green CI:** fix three failing conformance suites — `test_devin_liveness` (the bug above),
+  `test_windows_portability` (same BSD-first `stat` defect in its mode probes), and `test_cloud_gate`
+  (the cmd_bg preflight self-exec targeted the test harness under `source`; the test now points
+  `SCRIPT_PATH` at the real binary). New `test_watch_digest` locks the digest behavior.
+
 ## 0.4.22
 
 - **Hermes now works both ways.** The delegation lane (OUT) is wired for real: `delegate_hermes`

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
@@ -123,7 +123,7 @@ set -uo pipefail
 export PATH="$HOME/.local/bin:$PATH"
 # Version identifier. Single source of truth; bump the rightmost
 # number for patch releases. `doctor` and `--version` both read this.
-OSRC_VERSION="0.4.22"
+OSRC_VERSION="0.4.23"
 DEFAULT_MODEL="${OUTSOURCERER_MODEL:-glm-5.2}"
 
 # ---- platform detection (mac | linux | windows-gitbash). Windows = Git Bash / MSYS2, NO WSL
@@ -2499,8 +2499,7 @@ _devin_live_mtime() {
       # Symlink discipline, matching _devin_sandboxed_proxy_tls_hint: never stat through a
       # planted link.
       [ -L "$f" ] && continue
-      m="$(stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null)" || continue
-      [ -n "$m" ] || continue
+      m="$(_mtime "$f")"; [ -n "$m" ] || continue
       if [ -z "$newest" ] || [ "$m" -gt "$newest" ]; then newest="$m"; fi
     done
   done
@@ -3485,12 +3484,41 @@ cmd_status() {
   local d; for d in "$OSRC_JOBS"/*/; do [ -d "$d" ] || continue; _status_line "$(basename "$d")"; done
 }
 
+# _watch_digest <id> <interval-secs> <next-label> -> emit a periodic status digest to stdout.
+# No new state file, no background process: reads the same status/progress/started_at the watch
+# loop already reads. Gives a watched job a heartbeat into the running session even when nothing
+# has changed, so a long silent-but-healthy run does not look like a hang.
+_watch_digest() {
+  local id="$1" interval="$2" next="$3"
+  local jd="$OSRC_JOBS/$id"
+  local st prog started now elapsed
+  st="$(cat "$jd/status" 2>/dev/null || echo '?')"
+  prog="$(tail -1 "$jd/progress" 2>/dev/null)"
+  case "$prog" in
+    *OSRC::*) prog="OSRC::$(printf '%s' "${prog##*OSRC::}" | tr -d '"\\')" ;;
+    *) prog="(none yet)" ;;
+  esac
+  started="$(cat "$jd/started_at" 2>/dev/null)"
+  case "$started" in ''|*[!0-9]*) started="" ;; esac
+  now=$(date +%s)
+  if [ -n "$started" ]; then elapsed="$(( now - started ))s"; else elapsed="?"; fi
+  printf 'OSRC::PROGRESS watch %s periodic digest\n- state: %s\n- last: %s\n- elapsed: %s\n- next: %s\n' \
+    "$id" "$st" "$prog" "$elapsed" "$next"
+}
+
 cmd_watch() {
   _mark_watched "${1:-}"
   local id="${1:-}"; [ -n "$id" ] || die "watch needs a job id"
   local jd="$OSRC_JOBS/$id"; [ -d "$jd" ] || die "no such job: $id"
   local forsec=0; [ "${2:-}" = "--for" ] && forsec="${3:-60}"
   local t0; t0=$(date +%s); local last="" lastprog=""
+  # Periodic digest cadence: even with no state change, report into the running session so a long
+  # silent-but-healthy run does not look like a hang. OSRC_WATCH_DIGEST_SECS tunes it (default 420s).
+  local digest_secs="${OSRC_WATCH_DIGEST_SECS:-420}"
+  # Validate: a non-numeric value would error under set -u arithmetic; 0/negative would emit every
+  # poll (spam). Require a positive integer, else fall back to the default. (Sol review, MEDIUM.)
+  case "$digest_secs" in ''|*[!0-9]*|0) digest_secs=420 ;; esac
+  local last_digest; last_digest=$t0
   while :; do
     local st; st="$(cat "$jd/status" 2>/dev/null || echo '?')"
     # HEARTBEAT: print on a status change OR when a NEW OSRC::PROGRESS marker lands.
@@ -3500,7 +3528,18 @@ cmd_watch() {
     if [ "$st" != "$last" ] || { [ -n "$prog" ] && [ "$prog" != "$lastprog" ]; }; then
       _status_line "$id"; last="$st"; lastprog="$prog"
     fi
-    case "$st" in done|done?|failed|blocked|timeout|wedged|canceled|permission-blocked|interrupted) break ;; esac
+    # Terminal state FIRST: emit the final digest and break before a periodic tick could double it,
+    # and before --for could exit without it. (Sol review, both LOWs collapse to this ordering.)
+    case "$st" in done|done?|failed|blocked|timeout|wedged|canceled|permission-blocked|interrupted)
+      _watch_digest "$id" "$digest_secs" "fetch result"
+      break ;; esac
+    # Periodic digest: emit on the interval so the session sees the job is still alive even when
+    # status and progress are unchanged. Only reached while non-terminal, so it never doubles.
+    local _now; _now=$(date +%s)
+    if [ $(( _now - last_digest )) -ge "$digest_secs" ]; then
+      _watch_digest "$id" "$digest_secs" "continuing watch; next digest in ${digest_secs}s"
+      last_digest=$_now
+    fi
     [ "$forsec" -gt 0 ] && [ $(( $(date +%s) - t0 )) -ge "$forsec" ] && break
     sleep "${OSRC_POLL:-10}"
   done

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/conformance.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/conformance.sh
@@ -29,7 +29,7 @@ _ALL_SUITES="test_cloud_gate test_no_silent_escalation test_hardening test_escal
          test_devin_tls_diagnostics test_devin_printmode_hang test_lane_fallback test_interactive_default \
          test_harness_isolation test_autodetach test_advise test_claudex test_copilot \
          test_loops test_job_lifecycle test_output_truncation test_lane_accounting \
-         test_selfcontained_hardening test_trusted_lanes test_parity_links test_parity_hermes \
+         test_selfcontained_hardening test_trusted_lanes test_parity_links test_parity_hermes test_watch_digest \
          test_cc_devin_selfheal test_cloud_gate_coverage test_cost_disclosure \
          test_parser_parity test_resolved_lane test_limits_freshness test_gemini_lane test_watcher \
          test_marker_forgery test_loop_resume test_lane_liveness \

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_cloud_gate.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_cloud_gate.sh
@@ -19,6 +19,11 @@ mkdir -p "$OSRC_HOME"
 # sourced file, so keep every expansion default-safe.
 . "$SRC" >/dev/null 2>&1
 
+# When sourced (not exec'd), $0 is this test harness, so SCRIPT_PATH resolves to the TEST file
+# and cmd_bg's route preflight re-execs the test (rc=126 / recursion) instead of outsourcerer.sh.
+# Point it back at the real binary so the preflight self-exec targets it, as a real run would.
+SCRIPT_PATH="$SRC"
+
 pass=0; fail=0
 ok()  { echo PASS: $1; pass=$((pass+1)); }
 bad() { echo FAIL: $1; fail=$((fail+1)); }

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_watch_digest.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_watch_digest.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# test_watch_digest.sh — the watcher periodic digest (OSRC_WATCH_DIGEST_SECS) must:
+#   1) emit the documented OSRC::PROGRESS digest format,
+#   2) fall back to the default on a non-numeric / zero / negative interval (no set -u error, no spam),
+#   3) emit exactly ONE terminal digest and never double it with a periodic one (Sol review).
+# Built from the pain it fixes: a watched job that goes dark for its whole running phase reads as a
+# hang; and an unvalidated interval either errors under set -u or emits every single poll.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SRC="$SCRIPT_DIR/../outsourcerer.sh"
+[ -f "$SRC" ] || { echo "FAIL: cannot find $SRC"; exit 1; }
+bash -n "$SRC" || { echo "FAIL: bash -n failed"; exit 1; }
+
+pass=0; fail=0
+ok()  { echo "PASS: $1"; pass=$((pass+1)); }
+bad() { echo "FAIL: $1"; fail=$((fail+1)); }
+
+# Source-level: the feature + its validation must be present.
+grep -q '_watch_digest()' "$SRC" && ok "_watch_digest helper defined" || bad "_watch_digest missing"
+grep -q 'OSRC_WATCH_DIGEST_SECS' "$SRC" && ok "OSRC_WATCH_DIGEST_SECS wired" || bad "digest interval env missing"
+grep -q "in ''|\*\[!0-9\]\*|0) digest_secs=420" "$SRC" \
+  && ok "digest interval is validated (positive integer, else default)" \
+  || bad "digest interval is not validated"
+
+# Behavioural: isolated fake job dirs under a temp OSRC_HOME.
+export OSRC_HOME="$(mktemp -d)"; export OSRC_JOBS="$OSRC_HOME/jobs"
+trap 'rm -rf "$OSRC_HOME"' EXIT
+mkdir -p "$OSRC_JOBS/term"
+date +%s > "$OSRC_JOBS/term/started_at"
+echo done > "$OSRC_JOBS/term/status"
+
+# Terminal digest: exactly one "fetch result", zero "continuing" (no double-emit), correct format.
+out="$( . "$SRC" >/dev/null 2>&1; OSRC_WATCH_DIGEST_SECS=1 OSRC_POLL=1 cmd_watch term 2>&1 )"
+fr=$(printf '%s' "$out" | grep -c 'next: fetch result')
+cw=$(printf '%s' "$out" | grep -c 'continuing watch')
+[ "$fr" -eq 1 ] && ok "terminal state emits exactly one 'fetch result' digest" || bad "expected 1 terminal digest, got $fr"
+[ "$cw" -eq 0 ] && ok "terminal iteration does not also emit a periodic digest (no double-emit)" || bad "double-emit: $cw periodic digests alongside terminal"
+printf '%s' "$out" | grep -q 'OSRC::PROGRESS watch term periodic digest' \
+  && ok "digest uses the documented OSRC::PROGRESS header" || bad "digest header missing/wrong"
+printf '%s' "$out" | grep -qE '^- state: ' && printf '%s' "$out" | grep -qE '^- elapsed: ' \
+  && ok "digest carries state + elapsed bullets" || bad "digest bullets missing"
+
+# Bad interval must not error under set -u and must not spam: a running job watched --for 2 with a
+# garbage interval falls back to 420, so NO periodic 'continuing' digest fires in that window.
+mkdir -p "$OSRC_JOBS/run"; date +%s > "$OSRC_JOBS/run/started_at"; echo running > "$OSRC_JOBS/run/status"
+out2="$( . "$SRC" >/dev/null 2>&1; OSRC_WATCH_DIGEST_SECS=abc OSRC_POLL=1 cmd_watch run --for 2 2>&1 )"
+cw2=$(printf '%s' "$out2" | grep -c 'continuing watch')
+[ "$cw2" -eq 0 ] \
+  && ok "non-numeric interval falls back to default (no per-poll spam, no set -u error)" \
+  || bad "bad interval emitted $cw2 periodic digests (validation failed)"
+
+echo
+echo "RESULT: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_windows_portability.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_windows_portability.sh
@@ -161,7 +161,7 @@ case "$(uname -s 2>/dev/null)" in
     _mkdir_private "$TMP/posix-priv" >/dev/null 2>&1
     _mkdir_claim   "$TMP/posix-claim" >/dev/null 2>&1
     for d in posix-priv posix-claim; do
-      m="$(stat -f '%Lp' "$TMP/$d" 2>/dev/null || stat -c '%a' "$TMP/$d" 2>/dev/null)"
+      m="$(stat -c '%a' "$TMP/$d" 2>/dev/null || stat -f '%Lp' "$TMP/$d" 2>/dev/null)"
       [ "$m" = "700" ] && ok "POSIX mode still 700 for $d" || bad "POSIX mode for $d is $m, expected 700"
     done
     # The mode must be private from the MOMENT of creation, not merely by the time the helper
@@ -175,11 +175,11 @@ case "$(uname -s 2>/dev/null)" in
     CHSTUB="$TMP/chstub"; mkdir -p "$CHSTUB"
     printf '#!/usr/bin/env bash\nexit 0\n' > "$CHSTUB/chmod"; chmod +x "$CHSTUB/chmod"
     ( PATH="$CHSTUB:$PATH"; umask 000; _mkdir_private "$TMP/posix-born" >/dev/null 2>&1 )
-    m="$(stat -f '%Lp' "$TMP/posix-born" 2>/dev/null || stat -c '%a' "$TMP/posix-born" 2>/dev/null)"
+    m="$(stat -c '%a' "$TMP/posix-born" 2>/dev/null || stat -f '%Lp' "$TMP/posix-born" 2>/dev/null)"
     [ "$m" = "700" ] && ok "directory is born private under a hostile umask (no creation window)" \
                      || bad "born with mode $m under umask 000, expected 700 (creation window open)"
     ( PATH="$CHSTUB:$PATH"; umask 000; _mkdir_claim "$TMP/claim-born" >/dev/null 2>&1 )
-    m="$(stat -f '%Lp' "$TMP/claim-born" 2>/dev/null || stat -c '%a' "$TMP/claim-born" 2>/dev/null)"
+    m="$(stat -c '%a' "$TMP/claim-born" 2>/dev/null || stat -f '%Lp' "$TMP/claim-born" 2>/dev/null)"
     [ "$m" = "700" ] && ok "claimed directory is born private under a hostile umask" \
                      || bad "claimed dir born with mode $m under umask 000, expected 700"
     ;;


### PR DESCRIPTION
## What (v0.4.23)

Fixes the red CI on `main` (3 pre-existing conformance failures, one a real bug) and ships the watcher periodic-digest feature.

- **Watcher cadence** — `cmd_watch` emits a periodic `OSRC::PROGRESS` digest (state · last · elapsed · next) on `OSRC_WATCH_DIGEST_SECS` (default 420s) + a final digest on terminal state. A long silent-but-healthy run no longer reads as a hang. No new process/state file.
- **Real liveness bug** — `_devin_live_mtime` used a BSD-first `stat -f %m || stat -c %Y` that prints garbage and exits 0 on GNU/Linux, so a LIVE devin job's heartbeat was ignored → watchdog killed it as `wedged`. Now reuses the hardened `_mtime`.
- **Green CI** — `test_devin_liveness` (bug above), `test_windows_portability` (same BSD-first stat defect), `test_cloud_gate` (preflight self-exec targeted the harness under `source`). New `test_watch_digest` locks the feature.

## How it was built
Sol (`gpt-5.6-sol`) strategy/triage + review; GLM (Devin lane) execution; Claude orchestrate/judge. Sol's review caught 3 watcher defects (interval validation, double-emit, terminal-skip) — all fixed.

## Validation
Local: `test_cloud_gate` 54/0 (incl. CLIs-hidden CI-sim), `test_windows_portability` 18/0, `test_devin_liveness` 10/0, `test_watch_digest` 8/0. Full conformance clean but for INSTALL DRIFT (promote-only). CI on this PR is the real proof.
