### PR TITLE
fix: agy lane no longer rewrites an explicit, already-valid Gemini model id

### DIFF
--- a/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
@@ -9172,24 +9172,56 @@ delegate_ccnative() {
 
 # _agy_model_token <gemini-cli/api id> -> the token the Antigravity `agy` CLI accepts. agy exposes
 # its own curated (keyless) model set (see `agy models`); it has no flash-lite and uses non-preview
-# ids. agy is lenient (falls back to its default on an unknown token), so this is best-effort.
+# ids.
+#
+# NOTE: agy does NOT silently fall back on an unknown token -- it hard-errors
+# ("invalid model selection (--model X --effort Y)"), so a token this function emits must be one
+# agy actually serves.
+#
+# The `*flash*`/`*pro*` substring arms exist to translate gemini-API-only ids into agy's catalog
+# (strip `-preview`, collapse `flash-lite` since agy has no lite tier). But they matched on
+# SUBSTRING, so they also swallowed an id that was ALREADY a valid agy token: `-m gemini-3.7-flash`
+# dispatched gemini-3.5-flash instead, silently, with no indication a substitution had happened.
+# Any newer release agy adds hits the same path.
+#
+# So: an id already shaped like agy's catalog (`gemini-<ver>-flash[...]` / `gemini-<ver>-pro[...]`,
+# incl. effort-suffixed forms like gemini-3.6-flash-high) passes through unchanged -- EXCEPT the
+# `-preview`/`-lite` API-only suffixes, which agy rejects outright and which therefore must still
+# fall through to a family default. The two defaults are overridable because agy's catalog gains
+# new dated releases and a hardcoded default goes stale.
 _agy_model_token() {
   case "$1" in
-    *pro*)   echo "gemini-3.1-pro" ;;
-    *flash*) echo "gemini-3.5-flash" ;;   # covers flash + flash-lite (agy has no lite tier)
+    # API-only suffixes agy's catalog does not carry: must fall through to a family default below.
+    *-preview|*-lite) : ;;
+    # Already a valid agy token -> never rewrite an explicit, serveable model choice.
+    gemini-[0-9]*.[0-9]*-flash*|gemini-[0-9]*.[0-9]*-pro*) echo "$1"; return 0 ;;
+  esac
+  case "$1" in
+    *pro*)   echo "${OSRC_AGY_PRO_DEFAULT:-gemini-3.1-pro}" ;;
+    *flash*) echo "${OSRC_AGY_FLASH_DEFAULT:-gemini-3.5-flash}" ;;   # covers flash + flash-lite (agy has no lite tier)
     *)       echo "$1" ;;
   esac
 }
 
 # _agy_effort <agy-model-token> <requested-effort> -> an effort level that model actually accepts.
-# agy REQUIRES --effort for these models and rejects the run outright without it
+# agy REQUIRES --effort for a BARE family id and rejects the run outright without it
 # ("invalid model selection (--model X --effort \"\"): requires --effort"), and the accepted set is
 # per-model: pro offers low|high with NO medium, flash offers low|medium|high. An unsupported level is
 # rounded UP rather than down, because silently giving less thinking than asked for is the failure the
 # caller cannot see; the clamp is announced.
+# The mirror image also holds and is easy to miss: an id that already NAMES its effort must be sent
+# with NO --effort at all, because agy rejects that pair just as hard ("--model gemini-3.7-flash-high
+# conflicts with --effort=medium"). Returning empty here is the signal to drop the flag.
 _agy_effort() {
   local tok="$1" want="${2:-medium}" out
   case "$want" in low|medium|high) ;; *) want=medium ;; esac
+  case "$tok" in
+    # An id that already NAMES its effort takes no --effort flag: agy rejects the pair outright
+    # ("--model gemini-3.7-flash-high conflicts with --effort=medium"). Every id in agy's catalog is
+    # of this form, so this is the normal case for an explicitly pinned model, not an edge case.
+    # Emit nothing and let the caller omit the flag.
+    *-low|*-medium|*-high) return 0 ;;
+  esac
   case "$tok" in
     *pro*)   case "$want" in medium) out=high ;; *) out="$want" ;; esac ;;
     *flash*) out="$want" ;;
@@ -9233,13 +9265,18 @@ delegate_gmnative() {
     _tier_banner "antigravity-agy (keyless)" "$atok" "$ttier" "$posture | $(_lane_cost_disclosure gm)"
     # agy has no --output-format json; the supervisor watches plain-stdout byte growth and the bg
     # path derives last.txt from out.log, so no stream flags are needed. --print-timeout caps waits.
-    local aeff; aeff="$(_agy_effort "$atok" "${EFFORT:-medium}")"
+    local aeff aeffflag=(); aeff="$(_agy_effort "$atok" "${EFFORT:-medium}")"
+    if [ -n "$aeff" ]; then
+      aeffflag=(--effort "$aeff")
+    elif [ -n "${EFFORT:-}" ]; then
+      printf '>>> [effort] %s already names its effort, so --effort %s is dropped instead of sent (agy refuses the pair). Pick the -low/-medium/-high variant of the id to change it.\n' "$atok" "$EFFORT" >&2
+    fi
     # Capture stderr so a "timeout waiting for response" can be TRANSLATED. agy reports a dead lane the
     # same way it reports a slow one, and at the default 5m print-timeout that costs five minutes per
     # attempt to learn nothing. The distinguishing fact is that agy's own auth/model resolution
     # succeeded and only the generation never returned, which points at the backend, not the request.
     local _aerr; _aerr="$(mktemp -t osrc-agy)"
-    agy -p "$wrapped" ${aflag[@]+"${aflag[@]}"} --model "$atok" --effort "$aeff" \
+    agy -p "$wrapped" ${aflag[@]+"${aflag[@]}"} --model "$atok" ${aeffflag[@]+"${aeffflag[@]}"} \
         --print-timeout "${OSRC_AGY_PRINT_TIMEOUT:-5m}" 2> >(tee "$_aerr" >&2) || rc=$?
     if grep -qi 'timeout waiting for response' "$_aerr" 2>/dev/null; then
       printf '>>> [gemini] the keyless Antigravity lane accepted the request and never answered (model and login both resolved, so this is the Antigravity backend, not your prompt).\n' >&2

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_gemini_lane.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_gemini_lane.sh
@@ -77,6 +77,65 @@ awk '/timeout waiting for response/,/rm -f "\$_aerr"/' "$SRC" | grep -q 'rc=124'
   && ok "a lane that never answered exits non-zero (never mistaken for success)" \
   || bad "an unanswered request could still exit 0"
 
+# --- an explicit, serveable model choice must never be rewritten ---
+# The substring arms in _agy_model_token translate gemini-API-only ids into agy's catalog, but they
+# used to match on SUBSTRING alone, so they also swallowed ids that were ALREADY valid agy tokens:
+# `-m gemini-3.7-flash` dispatched gemini-3.5-flash, silently, with nothing in the output saying a
+# substitution had happened. Every newer release agy adds hits the same path, so this worsens over
+# time, and the caller's own effort/cost reasoning is made against a model that never ran.
+[ "$(_agy_model_token gemini-3.7-flash)" = "gemini-3.7-flash" ] \
+  && ok "an explicit newer flash release is dispatched as asked, not collapsed to the default" \
+  || bad "an explicit -m gemini-3.7-flash is still silently rewritten to another model"
+[ "$(_agy_model_token gemini-3.6-flash-high)" = "gemini-3.6-flash-high" ] \
+  && ok "an effort-suffixed agy id survives (agy serves these; they are not API-only forms)" \
+  || bad "an effort-suffixed agy id was rewritten"
+
+# ...but the translation those arms exist for must SURVIVE. agy does not silently fall back on an
+# unknown token, it hard-errors ("--effort is not supported for model X"), so passing an API-only
+# id straight through would turn the documented gemini-pro / gemini-flash-lite aliases into a hard
+# failure. These two are the ids the alias table actually resolves to.
+[ "$(_agy_model_token gemini-3.1-pro-preview)" = "gemini-3.1-pro" ] \
+  && ok "the -preview suffix is still stripped (agy rejects preview ids outright)" \
+  || bad "gemini-pro now resolves to a token agy refuses to run"
+[ "$(_agy_model_token gemini-3.1-flash-lite)" = "gemini-3.5-flash" ] \
+  && ok "flash-lite still collapses to flash (agy has no lite tier)" \
+  || bad "gemini-flash-lite now resolves to a token agy refuses to run"
+
+# --- passing an id through is only half the job: it must then be sent WITHOUT --effort ---
+# Found by running the real CLI rather than a fake one. Letting an explicit id survive the token map
+# (above) makes it reach agy for the first time, and agy refuses a model that already names its
+# effort if --effort is also present: "--model gemini-3.7-flash-high conflicts with --effort=medium".
+# This is the normal case, not an edge case — EVERY id in agy's published catalog carries a
+# -low/-medium/-high suffix, so before this, pinning any real model id was a guaranteed hard failure.
+for suffixed in gemini-3.7-flash-high gemini-3.6-flash-medium gemini-3.5-flash-low gemini-3.1-pro-low; do
+  [ -z "$(_agy_effort "$suffixed" medium 2>/dev/null)" ] \
+    && ok "$suffixed carries its own effort, so no --effort is produced for it" \
+    || bad "$suffixed would still be sent with --effort, the pair agy rejects"
+done
+
+# The bare-family path must be untouched by that: those ids carry no level, and agy refuses them
+# with an EMPTY effort just as hard, so dropping the flag everywhere would break the common case.
+[ -n "$(_agy_effort gemini-3.5-flash medium 2>/dev/null)" ] \
+  && ok "a bare family id still gets an effort (the flag is dropped only when the id names one)" \
+  || bad "the bare family id lost its --effort, which agy also refuses"
+
+# Assert the call site actually honours the empty return. The function can be right while the
+# dispatch still interpolates --effort unconditionally, which is exactly how this shipped.
+if grep -q -- '--model "$atok" ${aeffflag\[@\]+"${aeffflag\[@\]}"}' "$SRC"; then
+  ok "the agy dispatch builds --effort conditionally instead of always interpolating it"
+else
+  bad "the agy dispatch still passes --effort unconditionally"
+fi
+
+# The bare family defaults stay overridable: agy's catalog gains new dated releases, so a hardcoded
+# default goes stale and a caller needs a way to move it without waiting on this table.
+[ "$(OSRC_AGY_FLASH_DEFAULT=gemini-3.7-flash _agy_model_token flash)" = "gemini-3.7-flash" ] \
+  && ok "the bare flash default can be repinned without editing the table" \
+  || bad "OSRC_AGY_FLASH_DEFAULT does not move the bare flash default"
+[ "$(_agy_model_token flash)" = "gemini-3.5-flash" ] \
+  && ok "with the override unset the bare flash default is unchanged" \
+  || bad "the bare flash default changed when no override was set"
+
 echo
 echo "RESULT: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
### The problem

`_agy_model_token` exists to translate gemini-API-only ids into `agy`'s catalog:
strip the `-preview` suffix, and collapse `flash-lite` (agy has no lite tier).
But it matched on **substring**, so it also swallowed ids that were *already*
valid `agy` tokens:

```bash
_agy_model_token() {
  case "$1" in
    *pro*)   echo "gemini-3.1-pro" ;;
    *flash*) echo "gemini-3.5-flash" ;;
    *)       echo "$1" ;;
  esac
}
```

Any id containing `flash` became `gemini-3.5-flash`. So an explicit
`-m gemini-3.7-flash` dispatched `gemini-3.5-flash` instead — silently, with
nothing in the output indicating a substitution had happened:

```
$ ./outsourcerer.sh run -m gemini-3.7-flash --effort high "..."
>>> [antigravity-agy (keyless)] gemini-3.5-flash  tier=budget  ...
                                ^^^^^^^^^^^^^^^^ not what was asked for
```

`agy models` currently serves `gemini-3.5-flash`, `gemini-3.6-flash` and
`gemini-3.7-flash`, so two of the three are unreachable — and every future
release lands on the same path. The caller's effort and cost reasoning is made
against a model that never ran.

### The fix

An id already shaped like agy's catalog (`gemini-<ver>-flash...`,
`gemini-<ver>-pro...`, including effort-suffixed forms like
`gemini-3.6-flash-high`) passes through unchanged.

The `-preview` / `-lite` API-only suffixes are **excluded** from that
passthrough and still map to a family default. This part matters: agy does not
silently fall back on an unknown token, it hard-errors —

```
$ agy -p "..." --model gemini-3.1-pro-preview --effort high
Error: invalid model selection (--model "gemini-3.1-pro-preview" --effort "high"):
--effort is not supported for model "gemini-3.1-pro-preview"
```

— so a passthrough broad enough to leak those through would turn the documented
`gemini-pro` and `gemini-flash-lite` aliases into a hard failure. (The existing
comment claiming agy "is lenient (falls back to its default on an unknown
token)" is no longer accurate; updated.)

`OSRC_AGY_FLASH_DEFAULT` / `OSRC_AGY_PRO_DEFAULT` also let the two bare-family
defaults be repinned, since agy's catalog gains new dated releases and a
hardcoded default goes stale.

### The second half: `--effort` and the id are mutually exclusive

Passing the id through turned out to be only half the job, and the missing half
was only visible against the real CLI.

Letting an explicit id survive the token map makes it reach `agy` **for the
first time** — and agy refuses a model that already names its effort if
`--effort` is also present:

```
$ ./outsourcerer.sh run -m gemini-3.7-flash-high "..."
Error: invalid model selection (--model "gemini-3.7-flash-high" --effort "medium"):
--model gemini-3.7-flash-high conflicts with --effort=medium
```

This is the **normal** case, not an edge case: every id in agy's published
catalog carries a `-low`/`-medium`/`-high` suffix —

```
$ agy models
gemini-3.7-flash-high     Gemini 3.7 Flash (High)
gemini-3.7-flash-medium   Gemini 3.7 Flash (Medium)
gemini-3.7-flash-low      Gemini 3.7 Flash (Low)
gemini-3.1-pro-high       Gemini 3.1 Pro (High)
...
```

— so with only the first half of this fix, pinning any *real* catalog id was a
guaranteed hard failure. It went unnoticed because this lane's tests drive a
fake binary, which does not enforce the conflict.

So the constraint is two-sided, and both sides are hard errors:

| id form | `--effort` | agy's response |
|---|---|---|
| bare family (`gemini-3.5-flash`) | omitted | ❌ `requires --effort (low, medium, high)` |
| bare family (`gemini-3.5-flash`) | sent | ✅ runs |
| effort-suffixed (`gemini-3.7-flash-high`) | sent | ❌ `conflicts with --effort=medium` |
| effort-suffixed (`gemini-3.7-flash-high`) | omitted | ✅ runs |

`_agy_effort` now returns empty for an id that already names its effort, and the
dispatch builds the flag conditionally instead of interpolating `--effort`
unconditionally. The bare-family path is untouched, so the common case keeps the
flag it requires. An explicit `--effort` that the id's own suffix overrides is
announced rather than silently discarded:

```
>>> [effort] gemini-3.7-flash-low already names its effort, so --effort high is
    dropped instead of sent (agy refuses the pair). Pick the -low/-medium/-high
    variant of the id to change it.
```

## Behavior

| input | before | after |
|---|---|---|
| `gemini-3.1-pro-preview` (← `gemini-pro`) | `gemini-3.1-pro` | `gemini-3.1-pro` |
| `gemini-3.5-flash` (← `gemini-flash`) | `gemini-3.5-flash` | `gemini-3.5-flash` |
| `gemini-3.1-flash-lite` (← `gemini-flash-lite`) | `gemini-3.5-flash` | `gemini-3.5-flash` |
| `gemini-3.7-flash` (explicit) | `gemini-3.5-flash` ❌ | `gemini-3.7-flash` ✅ |
| `gemini-3.6-flash-high` (explicit) | `gemini-3.5-flash` ❌ | `gemini-3.6-flash-high`, no `--effort` ✅ |

Every id the alias table actually resolves to is unchanged; only ids that were
already valid agy tokens stop being rewritten, and only ids that name their own
effort stop being sent `--effort`.

## Tests

Adds coverage to `test_gemini_lane.sh`: **26 passed, 0 failed** on this branch
(6 assertions for the rewrite, 6 for the `--effort` conflict). Verified to fail
against the previous behavior and to guard both inverse mistakes:

- against `main`: the explicit 3.7 id is rewritten, the effort-suffixed id is
  rewritten, and there is no override knob
- against a too-broad passthrough that leaks `-preview`/`-lite`: `gemini-pro`
  and `gemini-flash-lite` resolve to tokens agy refuses
- against a fix that drops `--effort` unconditionally: the bare-family ids lose
  the flag agy requires from them
- one assertion checks the **call site**, not just the helper — the function can
  return empty while the dispatch still interpolates `--effort` regardless,
  which is exactly how the first revision of this PR shipped

Verified end-to-end against a real `agy` login (Antigravity CLI, Google AI Pro),
which is what surfaced the `--effort` conflict in the first place:

| command | before | after |
|---|---|---|
| `-m gemini-3.7-flash-high` | exit 1, never dispatched | exit 0, answers |
| `-m gemini-3.7-flash-low --effort high` | exit 1, never dispatched | exit 0, answers, prints the override notice |
| `-m gemini-flash` (bare alias) | exit 0 | exit 0, unchanged |

Also re-ran on this branch: `test_model_selection_parity.sh` 29/29,
`test_lane_fallback.sh` 20/20, `test_vocab_hygiene.sh` 25/25.

Full `conformance.sh` was run against the first revision of this branch:
**99 passed, 2 failed, 1 skipped**. Both failures
(`test_advise_dynamic_pool` → "unknown id wrongly passed `_catalog_validate`",
and `test_catalog_validation` → 17 passed / 2 failed) reproduce identically on a
clean checkout of `main` at 3113cbb, so they are pre-existing and not introduced
here. The live lane matrix was skipped (`OSRC_CONFORMANCE_LIVE` unset).
