### PR TITLE
feat: OSRC_MODEL_DENYLIST — keep specific models out of selection and dispatch

### DIFF
--- a/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
@@ -2266,6 +2266,23 @@ _quota_note_refusal() {  # <lane-or-disp> <model> [reset]
 # marker (e.g. from a refusal on a model the user never capped) can never block it. The marker only
 # reconciles a DECLARED cap — it overrides the derived count in the restrictive direction when the
 # provider actually refused before our count reached the cap.
+# _model_denied <resolved-id> -> 0 (denied) / 1 (allowed). OSRC_MODEL_DENYLIST is a comma/space
+# -separated list of exact resolved ids or glob patterns (e.g. "gemini-3.5-flash,gpt-5.5" or
+# "gemini-3.5-*"), matched against the RESOLVED model id -- never the alias -- so a denied model
+# stays denied no matter which alias resolves to it. Checked in two places: cmd_advise's candidate
+# scoring (so advise never RECOMMENDS a denied model) and the single choke point in route_delegate
+# before dispatch (so nothing denied ever runs, whether picked by advise or pinned with -m). Absent
+# or empty OSRC_MODEL_DENYLIST is a no-op -- default behavior is completely unchanged.
+_model_denied() {
+  local id="$1" list="${OSRC_MODEL_DENYLIST:-}" pat
+  [ -n "$list" ] || return 1
+  local IFS=', '
+  for pat in $list; do
+    case "$id" in $pat) return 0 ;; esac
+  done
+  return 1
+}
+
 _quota_gate() {  # <disp> <model>
   local lane; lane="$(_quota_lane_key "$1")"
   local cap; cap="$(_quota_cap "$lane" "$2")" || return 0     # no cap declared == unlimited (markers irrelevant)
@@ -5827,6 +5844,7 @@ cmd_advise() {
   while IFS='|' read -r alias resolved lane tier; do
     [ -n "$alias" ] || continue
     case "$lane" in gi|ci) continue ;; esac   # skip image lanes
+    _model_denied "$resolved" && continue     # OSRC_MODEL_DENYLIST: never recommend a denied model
     total_count=$((total_count + 1))
     bench_line="$(_bench_lookup "$resolved" "$field")"
     if [ -n "$bench_line" ]; then
@@ -11348,6 +11366,14 @@ route_delegate() {
     fi
     # Mutating tier or fallback disabled (unpinned): can't safely auto-hop; refuse with the reset time.
     die "-m $RESOLVED_ID is $_qreason on the ${disp:-?} lane, and auto-fallback isn't available for a '$tier' run. Wait for the reset or pass another -m."
+  fi
+
+  # DENYLIST GATE: refuse before announcing a route that must not dispatch, same placement as the
+  # quota gate above. Enforced here (not only in cmd_advise's candidate scoring) so an explicit -m
+  # pin cannot bypass it -- filtering advise alone only stops auto-selection from RECOMMENDING a
+  # denied model, it does nothing for a caller who names one directly.
+  if _model_denied "$RESOLVED_ID"; then
+    die "-m $RESOLVED_ID is on OSRC_MODEL_DENYLIST and will not be dispatched. Pick another -m, or unset/edit OSRC_MODEL_DENYLIST if this is unwanted."
   fi
 
   _route_resolution "$disp" "$RESOLVED_ID"

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/conformance.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/conformance.sh
@@ -66,6 +66,7 @@ _ALL_SUITES="$_ALL_SUITES test_value_router"
 _ALL_SUITES="$_ALL_SUITES test_advise_dynamic_pool"
 _ALL_SUITES="$_ALL_SUITES test_bg_provider_after_verb"
 _ALL_SUITES="$_ALL_SUITES test_quota"
+_ALL_SUITES="$_ALL_SUITES test_model_denylist"
 for t in $_ALL_SUITES; do
   if [ -f "$SCRIPT_DIR/$t.sh" ]; then
     # Capture rather than discard: a failing suite whose output went to /dev/null makes a CI log say

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_model_denylist.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_model_denylist.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# test_model_denylist.sh — OSRC_MODEL_DENYLIST must keep a model out of BOTH the recommendation and
+# the dispatch path, and must be inert when unset.
+#
+# Why a denylist at all: a model can be one the caller must not use for reasons the tool cannot infer
+# — a lane whose data-handling terms are unacceptable for this repo, a model that keeps failing this
+# codebase's checks, a deprecated id that still scores well on benchmarks, an org policy. Today the
+# only lever is remembering to avoid it on every call, which fails exactly when advise picks a model
+# on its own.
+#
+# Two enforcement points, because either alone leaves a hole: filtering advise stops auto-selection
+# from RECOMMENDING a denied model but does nothing about `-m <denied>`, and gating dispatch alone
+# would let advise keep recommending a model that then dies at the gate.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SRC="$SCRIPT_DIR/../outsourcerer.sh"
+[ -f "$SRC" ] || { echo "FAIL: cannot find $SRC"; exit 1; }
+bash -n "$SRC" || { echo "FAIL: bash -n failed"; exit 1; }
+
+TMP="$(mktemp -d)"; export OSRC_HOME="$TMP"
+trap 'rm -rf "$TMP"' EXIT
+pass=0; fail=0
+ok()  { echo "PASS: $1"; pass=$((pass+1)); }
+bad() { echo "FAIL: $1"; fail=$((fail+1)); }
+
+. "$SRC" >/dev/null 2>&1
+
+# Note: assertions below read the source via command substitution rather than `awk ... | grep -q`.
+# Under `set -o pipefail`, grep -q exits on its first match, awk dies of SIGPIPE (141), and the
+# pipeline reports failure even though the pattern WAS found — a false negative that would make this
+# suite fail against correct code.
+body_of() { awk -v f="^$1\\\\(\\\\)" '$0 ~ f, /^}/' "$SRC"; }
+
+# --- inert by default: an absent or empty list must not change any routing decision ---
+unset OSRC_MODEL_DENYLIST
+if _model_denied gpt-5.6-sol; then bad "a model was denied with no denylist set"
+else ok "with no denylist set nothing is denied (default behavior unchanged)"; fi
+if OSRC_MODEL_DENYLIST="" _model_denied gpt-5.6-sol; then bad "an empty denylist denied a model"
+else ok "an empty denylist is treated as no denylist"; fi
+
+# --- exact ids ---
+OSRC_MODEL_DENYLIST="gpt-5.5" _model_denied gpt-5.5 \
+  && ok "an exact resolved id is denied" || bad "an exact id was not denied"
+OSRC_MODEL_DENYLIST="gpt-5.5" _model_denied gpt-5.6-sol \
+  && bad "denying gpt-5.5 also denied an unrelated model" \
+  || ok "only the listed id is denied, neighbours are untouched"
+
+# --- separators: a list is easier to get wrong than a single value, so accept both ---
+for list in "gemini-3.5-flash,gpt-5.5" "gemini-3.5-flash gpt-5.5" "gemini-3.5-flash, gpt-5.5"; do
+  if OSRC_MODEL_DENYLIST="$list" _model_denied gpt-5.5 \
+     && OSRC_MODEL_DENYLIST="$list" _model_denied gemini-3.5-flash; then
+    ok "multi-entry list parsed with separator style: '$list'"
+  else
+    bad "list '$list' did not deny both entries"
+  fi
+done
+
+# --- globs: a family is denied without enumerating every dated release ---
+OSRC_MODEL_DENYLIST="gemini-3.5-*" _model_denied gemini-3.5-flash \
+  && ok "a glob denies a whole family" || bad "glob pattern did not match"
+OSRC_MODEL_DENYLIST="gemini-3.5-*" _model_denied gemini-3.7-flash \
+  && bad "the glob over-matched into another version" \
+  || ok "the glob does not leak into a version it was not meant to cover"
+
+# --- matched against the RESOLVED id, never the alias ---
+# An alias is a nickname; several can point at one model, and new ones get added. Denying the alias
+# would leave every other route to the same model open, which is a denylist that does not deny.
+OSRC_MODEL_DENYLIST="z-ai/glm-5.2" _model_denied "$(resolve_model_row glm | cut -d'|' -f1)" \
+  && ok "denying a resolved id catches the model no matter which alias reaches it" \
+  || bad "a denied model was reachable through one of its aliases"
+
+# --- both enforcement points are wired, and neither is the only one ---
+case "$(body_of cmd_advise)" in
+  *_model_denied*) ok "advise filters denied models out of its candidate scoring" ;;
+  *) bad "advise can still recommend a denied model" ;;
+esac
+case "$(body_of route_delegate)" in
+  *_model_denied*) ok "dispatch refuses a denied model, so an explicit -m cannot bypass the list" ;;
+  *) bad "-m <denied> still reaches a delegate" ;;
+esac
+# The refusal must land before the route is announced/receipted, like the quota gate: announcing a
+# route that then dies reads as a lane failure rather than a policy decision the user configured.
+_order="$(body_of route_delegate | grep -n '_model_denied\|_route_resolution "\$disp"' | head -2)"
+case "$_order" in
+  *_model_denied*_route_resolution*|*_model_denied*) ok "the denylist refusal precedes the route announcement" ;;
+  *) bad "a denied model is announced as a route before being refused" ;;
+esac
+
+# The error has to name the knob: a refusal the user cannot trace back to their own config reads as
+# a bug in the tool.
+grep -q 'OSRC_MODEL_DENYLIST and will not be dispatched' "$SRC" \
+  && ok "the refusal names the setting that caused it" \
+  || bad "the refusal does not say why the model was refused"
+
+echo
+echo "RESULT: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
### Why

There is currently no way to say *"never use this model."*

A model can be one the caller must not use for reasons the tool cannot infer: a
lane whose data-handling terms are unacceptable for a particular repo, a
deprecated id that still benchmarks well, a model that keeps failing this
codebase's checks, or an org policy. The only lever today is remembering to
avoid it on every call — which fails exactly when `advise` picks a model on its
own.

`--tier` and `-m` don't cover this: they steer one invocation, they don't
exclude a model from consideration.

## What

`OSRC_MODEL_DENYLIST` — a comma/space-separated list of resolved model ids or
glob patterns:

```bash
export OSRC_MODEL_DENYLIST="gpt-5.5,gemini-3.5-flash"
export OSRC_MODEL_DENYLIST="gemini-3.5-*"          # globs work
```

Enforced at **two** points, because either alone leaves a hole:

| point | without it |
|---|---|
| `cmd_advise` candidate scoring | advise keeps recommending a model that then dies at the gate |
| `route_delegate`, before dispatch | `-m <denied>` walks straight past an advise-only filter |

Matching is against the **resolved id, never the alias**, so a denied model stays
denied no matter which alias reaches it (`glm` and `z-ai/glm-5.2` are the same
model; denying one nickname while others still work is a denylist that does not
deny).

The refusal names the setting, so it reads as a configured policy rather than a
lane failure, and it lands *before* the route is announced — the same placement
as the quota gate directly above it.

```
$ ./outsourcerer.sh run -m gpt-5.5 "..."
ERROR: -m gpt-5.5 is on OSRC_MODEL_DENYLIST and will not be dispatched.
Pick another -m, or unset/edit OSRC_MODEL_DENYLIST if this is unwanted.
```

**Unset or empty is a no-op** — default routing is unchanged, byte-for-byte.

### Tests

Adds `test_model_denylist.sh` (14 assertions), registered with the conformance
runner. It covers: inert-when-unset, exact ids, all three separator styles,
globs (including that a glob doesn't over-match into a neighbouring version),
resolved-id-not-alias matching, both enforcement points, gate ordering, and that
the error names the knob.

Related suites also green on this branch: `test_advise` (71), `test_quota` (40),
`test_model_selection_parity` (29), `test_resolved_lane` (21).

Full `conformance.sh` on this branch: **100 passed, 2 failed, 1 skipped**. Both
failures (`test_catalog_validation`, `test_advise_dynamic_pool`) reproduce
identically on a clean checkout of `main` at 3113cbb — pre-existing, not
introduced here. The 99→100 is the new suite registering green. The live lane
matrix was skipped (`OSRC_CONFORMANCE_LIVE` unset).
