### PR TITLE
Guard devin dispatch against invalid-UTF-8 prompt crashes

### DIFF
--- a/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
@@ -233,6 +233,58 @@ live_models() {
   { devin --model "__list__" -p "x" </dev/null 2>&1 | grep -i "^Available:" | sed 's/^Available:[[:space:]]*//'; } || true
 }
 
+# _utf8_guard <string> -> prints <string> on stdout, lossy-decoded to valid UTF-8 if it
+# contained invalid bytes. The devin CLI (a Rust+clap binary) rejects any arg whose OsString
+# is not valid UTF-8 with "error: invalid UTF-8 was detected in one or more arguments" (rc=2)
+# — an opaque crash that does not name the prompt as the cause. The usual source is
+# byte-truncation upstream of outsourcerer: `awk substr` / `cut -c` slicing a multibyte
+# character mid-sequence leaves a lone start/continuation byte (e.g. em-dash E2 80 94 cut at
+# byte 7 yields a lone E2), which is invalid UTF-8. We catch it at the dispatch boundary so
+# the run proceeds with a visible warning instead of dying on an unattributed clap error.
+# Note: devin's --prompt-file does NOT avoid this — its file-read also rejects invalid UTF-8
+# ("stream did not contain valid UTF-8"), so the guard is needed regardless of channel.
+#
+# Happy path (valid UTF-8) returns the input UNTOUCHED via `printf '%s'` — no command-
+# substitution newline stripping, no warning. Callers that want zero happy-path change should
+# gate the call (see delegate/continue_turn): only route through `$(_utf8_guard ...)` when a
+# strict iconv check fails, so valid prompts never pass through a `$(...)`.
+#
+# Opt out: OSRC_UTF8_GUARD=0. No iconv, or a libiconv without the //IGNORE extension (musl,
+# some BSDs) -> best-effort passthrough (the strict check is portable; the lossy decode
+# degrades to passthrough rather than corrupting).
+_utf8_guard() {
+  [ "${OSRC_UTF8_GUARD:-1}" = "0" ] && { printf '%s' "$1"; return 0; }
+  command -v iconv >/dev/null 2>&1 || { printf '%s' "$1"; return 0; }
+  # Happy path: strict UTF-8->UTF-8 round-trip exits 0 only on valid input. Portable
+  # everywhere iconv exists (no //IGNORE needed). Returns input verbatim, no $() stripping.
+  printf '%s' "$1" | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1 && { printf '%s' "$1"; return 0; }
+  # Invalid UTF-8: lossy-decode so dispatch proceeds instead of dying on clap's opaque rc=2.
+  local clean
+  clean="$(printf '%s' "$1" | iconv -f UTF-8 -t UTF-8//IGNORE 2>/dev/null)"
+  # //IGNORE unsupported (musl/some BSDs) -> iconv errors, clean is empty -> passthrough the
+  # original so the real clap error surfaces (no silent corruption, just no guard here).
+  # All-invalid input also lands here -> same honest passthrough.
+  [ -z "$clean" ] && { printf '%s' "$1"; return 0; }
+  printf '>>> [utf8] prompt contained invalid UTF-8 bytes — lossy-decoded so dispatch proceeds. Common cause: byte-truncation upstream (awk substr / cut -c slicing a multibyte character mid-sequence, leaving a lone continuation byte that the devin CLI rejects with "invalid UTF-8 was detected in one or more arguments"). Fix the upstream truncation (truncate by codepoint, not byte) to avoid garbled content. Suppress: OSRC_UTF8_GUARD=0.\n' >&2
+  printf '%s' "$clean"
+  return 0
+}
+
+# _utf8_guard_prompt <varname> : guard IN PLACE — reassign the named var only when its value
+# is not valid UTF-8, so the happy path (valid prompt) is never touched by command
+# substitution (no trailing-newline stripping, no subshell). The invalid path routes through
+# _utf8_guard for the lossy decode + warning. Bash 3.2-safe (no nameref); uses eval with a
+# controlled var name only.
+_utf8_guard_prompt() {
+  [ "${OSRC_UTF8_GUARD:-1}" = "0" ] && return 0
+  command -v iconv >/dev/null 2>&1 || return 0
+  local _v _val
+  _v="$1"; eval "_val=\"\${$_v}\""
+  [ -n "$_val" ] || return 0
+  printf '%s' "$_val" | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1 && return 0
+  eval "$_v=\"\$(_utf8_guard \"\$_val\")\""
+}
+
 # delegate <perm> <sandbox-flag-or-empty> [-m MODEL] "<task>"
 delegate() {
   local perm="$1"; shift
@@ -240,6 +292,7 @@ delegate() {
   parse_model "$@"
   [ "${#REST[@]}" -gt 0 ] || die "no task prompt given"
   local prompt="${REST[*]}"
+  _utf8_guard_prompt prompt
   # Devin has no native reasoning-effort knob. If --effort was given, surface it as advisory
   # ONLY (it is consumed by parse_model, never passed to the devin CLI, which would 'unexpected argument').
   [ -n "${EFFORT:-}" ] && printf '>>> [effort] reasoning=%s (advisory only: Devin lane has no native effort knob; not sent to the CLI)\n' "$EFFORT" >&2
@@ -259,6 +312,7 @@ continue_turn() {
   parse_model "$@"
   [ "${#REST[@]}" -gt 0 ] || die "no follow-up prompt given"
   local prompt="${REST[*]}"
+  _utf8_guard_prompt prompt
   need_devin
   logged_in || die "Not logged in. Run:  ! devin auth login"
   echo ">>> devin -c --model $MODEL -p (continue)" >&2

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
@@ -236,52 +236,170 @@ live_models() {
 # _utf8_guard <string> -> prints <string> on stdout, lossy-decoded to valid UTF-8 if it
 # contained invalid bytes. The devin CLI (a Rust+clap binary) rejects any arg whose OsString
 # is not valid UTF-8 with "error: invalid UTF-8 was detected in one or more arguments" (rc=2)
-# — an opaque crash that does not name the prompt as the cause. The usual source is
+# -- an opaque crash that does not name the prompt as the cause. The usual source is
 # byte-truncation upstream of outsourcerer: `awk substr` / `cut -c` slicing a multibyte
 # character mid-sequence leaves a lone start/continuation byte (e.g. em-dash E2 80 94 cut at
 # byte 7 yields a lone E2), which is invalid UTF-8. We catch it at the dispatch boundary so
 # the run proceeds with a visible warning instead of dying on an unattributed clap error.
-# Note: devin's --prompt-file does NOT avoid this — its file-read also rejects invalid UTF-8
+# Note: devin's --prompt-file does NOT avoid this -- its file-read also rejects invalid UTF-8
 # ("stream did not contain valid UTF-8"), so the guard is needed regardless of channel.
 #
-# Happy path (valid UTF-8) returns the input UNTOUCHED via `printf '%s'` — no command-
-# substitution newline stripping, no warning. Callers that want zero happy-path change should
-# gate the call (see delegate/continue_turn): only route through `$(_utf8_guard ...)` when a
-# strict iconv check fails, so valid prompts never pass through a `$(...)`.
+# Two detection paths, picked per-host by a one-time probe (cached in OSRC_UTF8_PROBE):
+#   - iconv strict: `iconv -f UTF-8 -t UTF-8` exits non-zero on invalid input. Works on
+#     glibc and Apple/BSD libiconv. NOT on musl, whose iconv treats UTF-8->UTF-8 as a
+#     permissive passthrough (exits 0 on a lone E2) and lacks //IGNORE. On musl we fall back
+#     to a pure-shell byte validator (od + shell; no perl/python/iconv needed -- musl base
+#     Alpine ships neither perl nor python3).
+#   - shell: a POSIX UTF-8 framing check over `od -tu1` bytes. Portable everywhere od exists
+#     (od is already a dependency -- see _new_job_id). Used as the musl fallback for BOTH
+#     detection and the lossy strip (drop the invalid bytes), since musl has no //IGNORE.
 #
-# Opt out: OSRC_UTF8_GUARD=0. No iconv, or a libiconv without the //IGNORE extension (musl,
-# some BSDs) -> best-effort passthrough (the strict check is portable; the lossy decode
-# degrades to passthrough rather than corrupting).
+# Happy path (valid UTF-8) returns the input UNTOUCHED via `printf '%s'` -- no command-
+# substitution newline stripping, no warning, no subshell. Only an invalid prompt routes
+# through `$()` for the lossy decode. Opt out: OSRC_UTF8_GUARD=0.
 _utf8_guard() {
   [ "${OSRC_UTF8_GUARD:-1}" = "0" ] && { printf '%s' "$1"; return 0; }
-  command -v iconv >/dev/null 2>&1 || { printf '%s' "$1"; return 0; }
-  # Happy path: strict UTF-8->UTF-8 round-trip exits 0 only on valid input. Portable
-  # everywhere iconv exists (no //IGNORE needed). Returns input verbatim, no $() stripping.
-  printf '%s' "$1" | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1 && { printf '%s' "$1"; return 0; }
-  # Invalid UTF-8: lossy-decode so dispatch proceeds instead of dying on clap's opaque rc=2.
+  _utf8_valid "$1" && { printf '%s' "$1"; return 0; }
+  # Invalid: lossy-decode so dispatch proceeds instead of dying on clap's opaque rc=2.
   local clean
-  clean="$(printf '%s' "$1" | iconv -f UTF-8 -t UTF-8//IGNORE 2>/dev/null)"
-  # //IGNORE unsupported (musl/some BSDs) -> iconv errors, clean is empty -> passthrough the
-  # original so the real clap error surfaces (no silent corruption, just no guard here).
-  # All-invalid input also lands here -> same honest passthrough.
+  clean="$(_utf8_lossy "$1")"
+  # All-invalid input, or a platform that can't strip -> lossy returns empty. Don't swap in
+  # an empty prompt; let the real error surface honestly. The guard's job is partial
+  # corruption, not a totally mangled payload.
   [ -z "$clean" ] && { printf '%s' "$1"; return 0; }
-  printf '>>> [utf8] prompt contained invalid UTF-8 bytes — lossy-decoded so dispatch proceeds. Common cause: byte-truncation upstream (awk substr / cut -c slicing a multibyte character mid-sequence, leaving a lone continuation byte that the devin CLI rejects with "invalid UTF-8 was detected in one or more arguments"). Fix the upstream truncation (truncate by codepoint, not byte) to avoid garbled content. Suppress: OSRC_UTF8_GUARD=0.\n' >&2
+  # Re-validate the cleaned output before trusting it: an iconv that stops at the first bad
+  # byte (rather than skip-and-resume) would return only the valid PREFIX, silently
+  # truncating everything after the corruption. If clean isn't itself valid UTF-8, the
+  # decode is untrustworthy -- passthrough the original so the clap error surfaces instead
+  # of shipping a truncated prompt.
+  _utf8_valid "$clean" || { printf '%s' "$1"; return 0; }
+  printf '>>> [utf8] prompt contained invalid UTF-8 bytes -- lossy-decoded so dispatch proceeds. Common cause: byte-truncation upstream (awk substr / cut -c slicing a multibyte character mid-sequence, leaving a lone continuation byte that the devin CLI rejects with "invalid UTF-8 was detected in one or more arguments"). Fix the upstream truncation (truncate by codepoint, not byte) to avoid garbled content. Suppress: OSRC_UTF8_GUARD=0.\n' >&2
   printf '%s' "$clean"
   return 0
 }
 
-# _utf8_guard_prompt <varname> : guard IN PLACE — reassign the named var only when its value
+# _utf8_probe -> echoes "iconv" if `iconv -f UTF-8 -t UTF-8` actually rejects invalid UTF-8
+# (glibc/Apple/BSD), else "shell" (musl: permissive passthrough). Cached in OSRC_UTF8_PROBE
+# so the one-time bad-byte probe runs once per process. No iconv at all -> "shell" if od is
+# available, else "none" (guard is inert; the clap error surfaces, as it did before this).
+_utf8_probe() {
+  [ -n "${OSRC_UTF8_PROBE:-}" ] && { printf '%s' "$OSRC_UTF8_PROBE"; return 0; }
+  if command -v iconv >/dev/null 2>&1; then
+    # A lone 0xE2 (a 3-byte start with no continuation) is invalid UTF-8. If iconv's strict
+    # identity round-trip exits non-zero on it, iconv validates -- use it. musl exits 0.
+    if printf '\xe2' | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1; then
+      OSRC_UTF8_PROBE=shell
+    else
+      OSRC_UTF8_PROBE=iconv
+    fi
+  elif command -v od >/dev/null 2>&1; then
+    OSRC_UTF8_PROBE=shell
+  else
+    OSRC_UTF8_PROBE=none
+  fi
+  printf '%s' "$OSRC_UTF8_PROBE"
+}
+
+# _utf8_valid <string> -> rc0 if valid UTF-8, rc1 otherwise. Uses the probed path.
+_utf8_valid() {
+  local p; p="$(_utf8_probe)"
+  case "$p" in
+    iconv) printf '%s' "$1" | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1 ;;
+    shell) _utf8_valid_shell "$1" ;;
+    *) return 0 ;;   # none: cannot check, assume valid (honest passthrough)
+  esac
+}
+
+# _utf8_lossy <string> -> prints input with invalid UTF-8 bytes dropped (valid bytes kept).
+# Uses iconv //IGNORE where the probe confirmed iconv validates (glibc/Apple/BSD support
+# //IGNORE); on the shell path, strips via the byte validator. Empty output = all-invalid or
+# unsupported strip.
+_utf8_lossy() {
+  local p; p="$(_utf8_probe)"
+  case "$p" in
+    iconv) printf '%s' "$1" | iconv -f UTF-8 -t UTF-8//IGNORE 2>/dev/null ;;
+    shell) _utf8_lossy_shell "$1" ;;
+    *) printf '%s' "$1" ;;   # none: passthrough verbatim
+  esac
+}
+
+# _utf8_valid_shell <string> -> rc0 if valid UTF-8, rc1 otherwise. Pure POSIX (od + shell):
+# validates UTF-8 byte framing -- 1/2/3/4-byte sequences with correct continuation bytes,
+# rejects lone continuations, overlong starts (C0/C1), >0xF4, and truncated sequences. No
+# perl/python/iconv (musl base Alpine has none of those).
+_utf8_valid_shell() {
+  local b state need
+  state=0; need=0
+  # `od -tu1` emits bytes as decimal, one per line after tr. read -u3 avoids a pipe (pipefail
+  # would leak the reader's nonzero exit into our return).
+  exec 3< <(printf '%s' "$1" | od -An -tu1 -v | tr -s '[:space:]' '\n' | grep -v '^$')
+  while IFS= read -r b <&3; do
+    if [ "$state" = "0" ]; then
+      if [ "$b" -lt 128 ]; then :
+      elif [ "$b" -ge 194 ] && [ "$b" -le 223 ]; then state=1; need=1
+      elif [ "$b" -ge 224 ] && [ "$b" -le 239 ]; then state=1; need=2
+      elif [ "$b" -ge 240 ] && [ "$b" -le 244 ]; then state=1; need=3
+      else exec 3<&-; return 1  # lone continuation (80-BF), C0/C1, or F5+
+      fi
+    else
+      if [ "$b" -ge 128 ] && [ "$b" -le 191 ]; then
+        need=$((need-1)); [ "$need" = "0" ] && state=0
+      else exec 3<&-; return 1  # expected continuation, got something else
+      fi
+    fi
+  done
+  exec 3<&-
+  [ "$state" = "0" ]
+}
+
+# _utf8_lossy_shell <string> -> prints input with invalid bytes dropped. Walks the same UTF-8
+# framing as _utf8_valid_shell; on a framing error, drops the offending start/continuation
+# byte and resyncs (a start byte that doesn't begin a valid sequence, or a continuation that
+# doesn't follow one, is dropped). Valid bytes and complete multibyte chars are kept. Bytes
+# are reconstructed via printf octal escapes (\NNN) -- reliable across bash/dash/busybox,
+# unlike \xNN which needs two-digit hex and varies by shell.
+_utf8_lossy_shell() {
+  local b state need out char
+  state=0; need=0; out=""; char=""
+  exec 3< <(printf '%s' "$1" | od -An -tu1 -v | tr -s '[:space:]' '\n' | grep -v '^$')
+  while IFS= read -r b <&3; do
+    if [ "$state" = "0" ]; then
+      if [ "$b" -lt 128 ]; then out="$out$(printf "\\$(printf '%03o' "$b")")"
+      elif [ "$b" -ge 194 ] && [ "$b" -le 223 ]; then state=1; need=1; char="$(printf "\\$(printf '%03o' "$b")")"
+      elif [ "$b" -ge 224 ] && [ "$b" -le 239 ]; then state=1; need=2; char="$(printf "\\$(printf '%03o' "$b")")"
+      elif [ "$b" -ge 240 ] && [ "$b" -le 244 ]; then state=1; need=3; char="$(printf "\\$(printf '%03o' "$b")")"
+      fi  # else: lone continuation / bad start -> drop (resync)
+    else
+      if [ "$b" -ge 128 ] && [ "$b" -le 191 ]; then
+        char="$char$(printf "\\$(printf '%03o' "$b")")"
+        need=$((need-1)); [ "$need" = "0" ] && { out="$out$char"; char=""; state=0; }
+      else
+        # Expected a continuation but got a new start/bad byte: drop the partial char,
+        # reprocess this byte as a fresh start.
+        char=""; state=0; need=0
+        if [ "$b" -lt 128 ]; then out="$out$(printf "\\$(printf '%03o' "$b")")"
+        elif [ "$b" -ge 194 ] && [ "$b" -le 223 ]; then state=1; need=1; char="$(printf "\\$(printf '%03o' "$b")")"
+        elif [ "$b" -ge 224 ] && [ "$b" -le 239 ]; then state=1; need=2; char="$(printf "\\$(printf '%03o' "$b")")"
+        elif [ "$b" -ge 240 ] && [ "$b" -le 244 ]; then state=1; need=3; char="$(printf "\\$(printf '%03o' "$b")")"
+        fi
+      fi
+    fi
+  done
+  exec 3<&-
+  printf '%s' "$out"
+}
+
+# _utf8_guard_prompt <varname> : guard IN PLACE -- reassign the named var only when its value
 # is not valid UTF-8, so the happy path (valid prompt) is never touched by command
 # substitution (no trailing-newline stripping, no subshell). The invalid path routes through
 # _utf8_guard for the lossy decode + warning. Bash 3.2-safe (no nameref); uses eval with a
 # controlled var name only.
 _utf8_guard_prompt() {
   [ "${OSRC_UTF8_GUARD:-1}" = "0" ] && return 0
-  command -v iconv >/dev/null 2>&1 || return 0
   local _v _val
   _v="$1"; eval "_val=\"\${$_v}\""
   [ -n "$_val" ] || return 0
-  printf '%s' "$_val" | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1 && return 0
+  _utf8_valid "$_val" && return 0
   eval "$_v=\"\$(_utf8_guard \"\$_val\")\""
 }
 

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/conformance.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/conformance.sh
@@ -26,7 +26,7 @@ echo "=== STATIC gate: Phase-0 invariants wired ==="
 
 # 1. Every unit test suite is green (aggregate).
 for t in test_cloud_gate test_no_silent_escalation test_hardening test_escalation_classify \
-         test_lane_fallback test_interactive_default test_harness_isolation test_autodetach; do
+         test_lane_fallback test_interactive_default test_harness_isolation test_autodetach test_utf8_guard; do
   if [ -f "$SCRIPT_DIR/$t.sh" ]; then
     if bash "$SCRIPT_DIR/$t.sh" >/dev/null 2>&1; then ok "unit suite $t green"; else bad "unit suite $t FAILED"; fi
   else note "unit suite $t absent"; fi

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_utf8_guard.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_utf8_guard.sh
@@ -101,6 +101,35 @@ P=""
 _utf8_guard_prompt P
 [ -z "$P" ] && ok "_utf8_guard_prompt is a no-op on an empty prompt var" || bad "_utf8_guard_prompt altered an empty var: [$P]"
 
+# --- Scenario 13: the shell fallback path (musl: no //IGNORE, permissive strict iconv)
+# works end-to-end. Force the probe to "shell" to exercise the pure-shell validator + lossy
+# stripper regardless of host iconv. This is what runs on Alpine/musl. ---
+SAVE_PROBE="${OSRC_UTF8_PROBE:-}"
+OSRC_UTF8_PROBE=shell
+out="$(OSRC_UTF8_PROBE=shell _utf8_guard "$INVALID" 2>/dev/null)"
+[ "$out" = "hello  world" ] && ok "shell path: invalid UTF-8 lossy-decoded (musl fallback)" || bad "shell path lossy-decode wrong: got [$out]"
+OSRC_UTF8_PROBE=shell _utf8_guard "$VALID" 2>"$TMP_ERR" > "$TMP/shell-valid"
+cmp -s "$TMP/shell-valid" <(printf '%s' "$VALID") && ok "shell path: valid non-ASCII passes unchanged" || bad "shell path altered valid input"
+warn="$(cat "$TMP_ERR" 2>/dev/null)"; [ -z "$warn" ] && ok "shell path: no false warning on valid input" || bad "shell path false warning: $warn"
+# 4-byte valid char (U+10308 = F0 90 8C 88) preserved through the shell path.
+out="$(OSRC_UTF8_PROBE=shell _utf8_lossy $'x\xf0\x90\x8c\x88y' 2>/dev/null)"
+[ "$out" = $'x\xf0\x90\x8c\x88y' ] && ok "shell path: 4-byte valid char preserved" || bad "shell path dropped a valid 4-byte char: got [$out]"
+OSRC_UTF8_PROBE="$SAVE_PROBE"
+
+# --- Scenario 14: invalid byte at END of prompt (not just mid-string). ---
+# A lone E2 with no following bytes at EOF is a truncated 3-byte sequence.
+ENDBAD=$'hello world\xe2'
+out="$(_utf8_guard "$ENDBAD" 2>/dev/null)"
+[ "$out" = "hello world" ] && ok "invalid byte at end-of-prompt is stripped" || bad "end-of-prompt byte not stripped: got [$out]"
+
+# --- Scenario 15: the probe picks iconv on a validating iconv, shell on a permissive one. ---
+# We can't force musl here, but we CAN confirm the probe returns a non-empty known value and
+# that forcing it to "none" makes the guard inert (honest passthrough, no corruption).
+p="$(_utf8_probe)"
+case "$p" in iconv|shell|none) ok "probe returns a known value ($p)" ;; *) bad "probe returned unknown value: [$p]" ;; esac
+out="$(OSRC_UTF8_PROBE=none _utf8_guard "$INVALID" 2>/dev/null)"
+[ "$out" = "$INVALID" ] && ok "probe=none: guard is inert (honest passthrough, no corruption)" || bad "probe=none altered input: got [$out]"
+
 echo "---"
 echo "utf8_guard: $pass passed, $fail failed"
 [ "$fail" -eq 0 ] || exit 1

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_utf8_guard.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_utf8_guard.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# test_utf8_guard.sh — U? conformance: the devin dispatch boundary must not die on the opaque
+# clap error "invalid UTF-8 was detected in one or more arguments" when a prompt contains
+# broken bytes (the real-world source is byte-truncation upstream: awk substr / cut -c slicing
+# a multibyte character mid-sequence, leaving a lone continuation byte). _utf8_guard lossy-
+# decodes so dispatch proceeds with a visible warning instead of an unattributed rc=2 crash.
+#
+# Run: bash test_utf8_guard.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SRC="$SCRIPT_DIR/../outsourcerer.sh"
+[ -f "$SRC" ] || { echo "FAIL: cannot find $SRC"; exit 1; }
+bash -n "$SRC" || { echo "FAIL: bash -n failed for $SRC"; exit 1; }
+
+have() { command -v "$1" >/dev/null 2>&1; }
+pass=0; fail=0
+ok()   { echo "PASS: $1"; pass=$((pass+1)); }
+bad()  { echo "FAIL: $1"; fail=$((fail+1)); }
+
+TMP="$(mktemp -d)"; TMP_ERR="$TMP/err"; : > "$TMP_ERR"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+# Source the main script for function access (it guards its own entrypoint with a main-runnable
+# check, so sourcing defines functions without executing dispatch).
+. "$SRC" >/dev/null 2>&1
+
+# --- Scenario 1: valid UTF-8 non-ASCII passes through unchanged. ---
+# Em-dash (U+2014, E2 80 94), arrow, curly quotes, accented letters are all VALID UTF-8 and
+# must NOT be altered or warned about. This is the regression guard against the original
+# misdiagnosis ("non-ASCII crashes it").
+VALID="hello — world → test 'curly' "café""
+out="$(_utf8_guard "$VALID" 2>/dev/null)"
+[ "$out" = "$VALID" ] && ok "valid UTF-8 non-ASCII passes unchanged" || bad "valid non-ASCII was altered: got [$out]"
+
+# --- Scenario 2: invalid UTF-8 (lone 0xE2 start byte) is lossy-decoded, warning emitted. ---
+# This is the exact byte sequence awk substr produces when truncating "hello — world" at 7
+# bytes: the em-dash's first byte E2 is left alone without its continuation bytes.
+INVALID=$'hello \xe2 world'
+warn=""
+out="$(_utf8_guard "$INVALID" 2>"$TMP_ERR")"; warn="$(cat "$TMP_ERR" 2>/dev/null)"
+# iconv //IGNORE drops the lone E2 -> "hello  world" (double space where the byte was).
+[ "$out" = "hello  world" ] && ok "invalid UTF-8 lossy-decoded to valid" || bad "lossy-decode wrong: got [$out]"
+printf '%s' "$warn" | grep -q '\[utf8\]' && ok "warning emitted on invalid UTF-8" || bad "no warning on invalid UTF-8"
+
+# --- Scenario 3: the guard's output is itself valid UTF-8 (would not re-trip clap). ---
+# Round-trip the cleaned output through iconv strict (no //IGNORE); must exit 0.
+printf '%s' "$out" | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1 && ok "cleaned output is valid UTF-8" || bad "cleaned output still invalid UTF-8"
+
+# --- Scenario 4: OSRC_UTF8_GUARD=0 opts out (passthrough, no warning, no decode). ---
+out="$(OSRC_UTF8_GUARD=0 _utf8_guard "$INVALID" 2>/dev/null)"
+[ "$out" = "$INVALID" ] && ok "OSRC_UTF8_GUARD=0 passes invalid bytes through verbatim" || bad "opt-out altered input: got [$out]"
+
+# --- Scenario 5: empty-after-decode fallback — a fully-invalid payload is NOT replaced with
+# an empty string (an empty prompt is a different failure); the original is returned so the
+# real error surfaces honestly. ---
+ALLBAD=$'\xe2\xe2\xe2'
+out="$(_utf8_guard "$ALLBAD" 2>/dev/null)"
+[ "$out" = "$ALLBAD" ] && ok "all-invalid payload returned verbatim (no empty swap)" || bad "all-invalid payload was swapped: got [$out]"
+
+# --- Scenario 6: empty input is a no-op. ---
+out="$(_utf8_guard "" 2>/dev/null)"
+[ -z "$out" ] && ok "empty input returns empty" || bad "empty input returned non-empty: [$out]"
+
+# --- Scenario 7: the guard is wired into delegate() and continue_turn(). ---
+# Static check: both dispatch sites call _utf8_guard_prompt before the devin invocation.
+delegate_calls=$(grep -c '_utf8_guard_prompt prompt' "$SRC")
+[ "$delegate_calls" -ge 2 ] && ok "delegate() and continue_turn() both call _utf8_guard_prompt ($delegate_calls sites)" || bad "guard not wired into both dispatch sites (found $delegate_calls)"
+
+# --- Scenario 8: no iconv -> best-effort passthrough (cannot check, do not corrupt). ---
+# Stub iconv to be absent and confirm valid input passes through unchanged.
+_utf8_guard_noiconv() { PATH="/dev/null" command -v iconv >/dev/null 2>&1 || { printf '%s' "$1"; return 0; }; }
+out="$(_utf8_guard_noiconv "$VALID")"
+[ "$out" = "$VALID" ] && ok "no-iconv passthrough preserves valid input" || bad "no-iconv path corrupted input"
+
+# --- Scenario 9: valid multi-line prompt ending in newline is NOT altered and NOT warned. ---
+# Regression guard against command-substitution trailing-newline stripping + false positives.
+# _utf8_guard's happy path must return the input verbatim on stdout. Compare BYTE-EXACT via
+# files (cmp), NOT via $(...) which strips trailing newlines itself and would mask the check.
+ML=$'line one\nline two\n'
+printf '%s' "$ML" > "$TMP/expected"
+_utf8_guard "$ML" 2>"$TMP_ERR" > "$TMP/actual"
+cmp -s "$TMP/expected" "$TMP/actual" && ok "valid multi-line prompt (trailing newline) passes byte-exact unchanged" || bad "multi-line trailing-newline prompt was altered"
+warn="$(cat "$TMP_ERR" 2>/dev/null)"
+[ -z "$warn" ] && ok "no false warning on valid multi-line prompt" || bad "false warning on valid multi-line prompt: $warn"
+
+# --- Scenario 10: _utf8_guard_prompt guards IN PLACE — valid prompt var is untouched. ---
+# The happy path must not route through command substitution (no trailing-newline stripping).
+P="$ML"
+_utf8_guard_prompt P
+[ "$P" = "$ML" ] && ok "_utf8_guard_prompt leaves a valid prompt var untouched (no $() stripping)" || bad "_utf8_guard_prompt altered a valid prompt: got [$P]"
+
+# --- Scenario 11: _utf8_guard_prompt reassigns an invalid prompt var in place. ---
+P="$INVALID"
+_utf8_guard_prompt P
+[ "$P" = "hello  world" ] && ok "_utf8_guard_prompt lossy-decodes an invalid prompt var in place" || bad "_utf8_guard_prompt in-place decode wrong: got [$P]"
+
+# --- Scenario 12: _utf8_guard_prompt is a no-op on an empty var. ---
+P=""
+_utf8_guard_prompt P
+[ -z "$P" ] && ok "_utf8_guard_prompt is a no-op on an empty prompt var" || bad "_utf8_guard_prompt altered an empty var: [$P]"
+
+echo "---"
+echo "utf8_guard: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
## What

A guard at the devin dispatch boundary so a prompt containing broken bytes doesn't kill the run with an opaque error. Adds `_utf8_guard` / `_utf8_guard_prompt` (plus a host probe and a pure-shell fallback) and wires them into `delegate()` and `continue_turn()`, with a test suite.

## Why

When outsourcerer hands the devin CLI a prompt via `-p "$prompt"`, devin's arg parser (Rust + clap) rejects any argument whose bytes aren't valid UTF-8:

```
error: invalid UTF-8 was detected in one or more arguments
```

That's clap's stock `ErrorKind::InvalidUtf8` (rc=2). It's an opaque crash — it doesn't tell you the *prompt* is the problem, and it doesn't tell you *why* the bytes are bad. In practice the trigger isn't exotic Unicode; it's byte-truncation upstream of outsourcerer. Tools like `awk substr` or `cut -c` that slice by **byte** can split a multibyte character mid-sequence and leave a lone start/continuation byte, which is invalid UTF-8.

A common one: an em-dash (`—`, `E2 80 94`) truncated at byte 7 leaves a lone `E2`. That single byte is what trips clap.

Two things worth stating plainly, because they're easy to get backwards:

- **Valid non-ASCII is fine.** Em-dashes, arrows, curly quotes, accents are all valid UTF-8 and pass through `-p` (and `--`) without error. The crash is *invalid bytes*, not *non-ASCII characters*.
- **`--prompt-file` is not a fix.** I checked it hoping it would bypass the argv path, but devin's file-read rejects invalid UTF-8 too (`Failed to read prompt file ...: stream did not contain valid UTF-8`). So switching channels just relocates the failure. The guard is needed regardless.

## How

`_utf8_guard_prompt <varname>` runs in place before dispatch:

- **Happy path (valid UTF-8):** the prompt variable is left completely untouched — no command substitution, no subshell, no trailing-newline stripping. Zero behavior change for valid prompts.
- **Invalid path:** lossy-decode (invalid bytes dropped) so dispatch proceeds, and a visible `>>> [utf8]` warning names the likely cause and the upstream fix (truncate by codepoint, not byte).
- **Re-validate before trusting:** the cleaned output is re-checked for valid UTF-8 before it's accepted. An iconv that stops at the first bad byte (rather than skip-and-resume) would return only the valid prefix, silently truncating everything after the corruption — if the clean output isn't itself valid, the original is passed through so the real error surfaces instead of a truncated prompt.
- **Opt out:** `OSRC_UTF8_GUARD=0`.

The guard deliberately **doesn't** silently fix the root cause — it gets the run moving and tells the user their upstream truncation is breaking multibyte text, so they fix it at the source.

### Detection path is host-selected (musl-safe)

A one-time probe (`_utf8_probe`, cached in `OSRC_UTF8_PROBE`) picks the detection path per host:

- **iconv** (glibc, Apple/BSD libiconv): `iconv -f UTF-8 -t UTF-8` rejects invalid input, and `//IGNORE` is supported for the lossy decode. Fast path.
- **shell** (musl): musl's iconv treats UTF-8→UTF-8 as a permissive passthrough (exits 0 on a lone `E2`) and lacks `//IGNORE`, so the strict-check fast path would silently no-op. The fallback is a pure-shell UTF-8 byte validator + lossy stripper built on `od` + shell — no perl/python/iconv needed (musl base Alpine ships none of those). `od` is already a dependency (see `_new_job_id`).
- **none:** no `iconv` and no `od` → the guard is inert; the clap error surfaces as it did before.

The contract is identical across paths (valid UTF-8 unchanged; invalid → lossy-decoded to valid UTF-8 + warning). Verified on macOS (iconv path) and an Alpine/musl container (shell path, probe auto-detected).

### Deterministic

The guard is pure code (iconv + shell byte-walking), no model judgment — same input on the same host always yields the same output, so the test suite is reproducible. The detection path is host-selected, and for unusual inputs (overlong encodings, certain edge sequences) the iconv and shell paths could drop slightly different bytes (independent framing logic). For the common case — truncated multibyte sequences, the actual real-world trigger — they agree.

## Repro

devin 3000.4.25, macOS. Using `--model __list__` (an invalid model that errors at validation before any session starts) to isolate the arg-parsing stage:

```sh
# 1) Valid non-ASCII passes (reaches model validation, no UTF-8 error):
devin --model __list__ --respect-workspace-trust false -p "hello — world → café"

# 2) Invalid UTF-8 (lone 0xE2) crashes:
devin --model __list__ --respect-workspace-trust false -p $'hello \xe2 world'
# -> error: invalid UTF-8 was detected in one or more arguments  (rc=2)

# 3) The real-world trigger — awk substr truncating mid-em-dash:
TRUNC=$(printf 'hello — world' | awk '{print substr($0,1,7)}')
printf '%s' "$TRUNC" | xxd
# -> 6865 6c6c 6f20 e2   (lone E2 — the em-dash's first byte, no continuation)
devin --model __list__ --respect-workspace-trust false -p "$TRUNC"
# -> error: invalid UTF-8 was detected in one or more arguments  (rc=2)

# 4) --prompt-file does NOT escape it:
printf 'hello \xe2 world' > /tmp/bad.txt
devin --model __list__ --respect-workspace-trust false --prompt-file /tmp/bad.txt
# -> Error: Failed to read prompt file ...: stream did not contain valid UTF-8
```

With the guard in place, case 3 lossy-decodes to `hello ` + a warning, and devin accepts the prompt (reaches model validation instead of crashing).

## Tests

New `test_utf8_guard.sh` (21 scenarios): valid non-ASCII unchanged, invalid lossy-decoded + warned, cleaned output re-validates as UTF-8, opt-out passthrough, all-invalid honest passthrough, empty no-op, **valid multi-line prompt with trailing newline passes byte-exact unchanged** (regression guard against command-substitution stripping + false warnings), in-place guard leaves valid prompts untouched / decodes invalid in place / no-op on empty, **shell fallback path** (forced probe, exercises the musl pure-shell validator + stripper), invalid byte at end-of-prompt, probe returns a known value / `none` is inert, and a static check that both dispatch sites are wired. Added to the `conformance.sh` aggregate.

```
test_utf8_guard: 21 passed, 0 failed   (macOS iconv path AND Alpine/musl shell path)
conformance.sh:  macOS 21 passed, 0 failed, 1 skipped (live probes opt-in)
                 Alpine 19 passed, 2 failed, 1 skipped (the 2 failures — test_hardening,
                 test_harness_isolation — are pre-existing on the base commit, unrelated)
```

#### Test plan

- [x] `bash tests/test_utf8_guard.sh` → 21/21 on macOS and Alpine/musl
- [x] `bash tests/conformance.sh` static gate → macOS 21/0/1
- [x] `bash -n outsourcerer.sh` clean
- [x] End-to-end: awk-truncated prompt → guard lossy-decodes + warns → devin accepts (no clap crash)
- [x] Happy path: valid multi-line prompt with trailing newline reaches devin byte-exact, no warning
- [x] musl: probe auto-detects `shell` on Alpine; pure-shell validator + stripper handle valid/invalid/4-byte/trailing-newline
