### PR TITLE
fix(watchdog): kill re-parented grandchildren via process-group SIGKILL

### DIFF
--- a/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
@@ -6138,6 +6138,58 @@ _kill_process_group() { # <pgid> <root-pid>
   return 1
 }
 
+# _kill_job <job-dir> <root-pid> — tear down a supervised job's whole tree, reaching
+# grandchildren that the ppid walk cannot. _supervise launches its delegate as its own
+# process-group leader and records that PGID in <job-dir>/pgid. PGID membership survives
+# reparenting: when the direct child dies on SIGTERM, a grandchild that ignored TERM is
+# re-parented to PID 1, leaves the process tree, and the SECOND _descendants snapshot
+# (the one _kill_tree takes for its KILL pass) no longer sees it — so the grandchild
+# keeps its inherited socket/file and the kill floor never reaps. Incident: a wedged
+# `devin acp` held an ESTABLISHED TCP to the model backend for 4h21m (15,660s), 8.7x past
+# the 1800s devin stall-kill floor, because its parent `devin -p` died on TERM and it
+# re-parented out of the tree before the KILL pass re-discovered it. Killing the process
+# group by negative PGID reaches every member regardless of reparenting; SIGKILL on the
+# group cannot be caught, so a grandchild that ignores SIGTERM still dies. Falls back to
+# _kill_tree when no isolated PGID was recorded, so a launch that could not be isolated
+# (or an old job dir written before this fix) degrades to the prior behaviour instead of
+# signalling the wrong group.
+_kill_job() {
+  local jd="${1:-}" pid="${2:-}" pgid="" _live_pgid=""
+  case "$pid" in ''|*[!0-9]*) return 0 ;; esac
+  [ -n "$jd" ] && [ -f "$jd/pgid" ] && pgid="$(cat "$jd/pgid" 2>/dev/null | tr -d '[:space:]')"
+  case "$pgid" in ''|*[!0-9]*) pgid="" ;; esac
+  if [ -n "$pgid" ]; then
+    # PID-reuse / stale-PGID guard: the recorded PGID is only safe to kill by negative
+    # ID when the root PID is still alive AND still in that group. A job dir from a
+    # long-finished job (cmd_cleanup can be called days later) may hold a PGID that the
+    # OS has since recycled into an unrelated group — killing `-PGID` then hits an
+    # innocent process group. Verify the live process's PGID matches the record; if the
+    # PID is dead, has a different PGID, or ps is unavailable, fall back to the tree
+    # walk (which is harmless on a dead PID). This collapses the recycling risk to
+    # "both the PID and its PGID were recycled together", which requires the group
+    # leader to be reborn in the same group.
+    _live_pgid="$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d ' ')"
+    case "$_live_pgid" in ''|*[!0-9]*) pgid="" ;; *[!0-9]*) pgid="" ;; esac
+    [ -n "$pgid" ] && [ "$_live_pgid" = "$pgid" ] || pgid=""
+  fi
+  if [ -n "$pgid" ]; then
+    _kill_process_group "$pgid" "$pid"
+    local _krc=$?
+    # _kill_process_group returns 1 when live survivors remain after the KILL pass.
+    # That is the one signal that answers "did the kill actually land?" — discarding
+    # it silently (the prior behaviour at every call site) is exactly the incident
+    # pattern: the watchdog believed it had reaped the job for 4h21m. Record it so a
+    # recurrence is loud instead of silent. The caller's exit code (125/124/3) is
+    # unchanged — this is diagnostic, not a new exit path.
+    if [ "$_krc" -ne 0 ] && [ -n "$jd" ] && [ -d "$jd" ]; then
+      printf 'kill-survivors-remain\n' >> "$jd/reason" 2>/dev/null || true
+    fi
+    return "$_krc"
+  else
+    _kill_tree "$pid"
+  fi
+}
+
 # _perm_denials <log> -> count of REAL permission/sandbox denials in the log's tail.
 #
 # The naive version of this — grep the whole log for 'permission denied|EACCES|...' — counts the
@@ -6297,8 +6349,36 @@ _supervise() {
   _mkdir_private "$jd"
   : > "$jd/out.log"; chmod 600 "$jd/out.log" 2>/dev/null || true
   echo running > "$jd/status"
+  # Launch the delegate as its OWN process-group leader so a wedged descendant that
+  # re-parents to PID 1 when its parent dies can still be reached by `kill -- -PGID`.
+  # The ppid tree walk alone misses exactly that case: a grandchild immune to SIGTERM
+  # survives the TERM pass, its parent dies on TERM, it re-parents out of the tree, and
+  # the KILL pass's re-snapshot never re-discovers it — so it keeps its inherited
+  # socket/file and the stall-kill floor never reaps (incident: devin acp held an
+  # ESTABLISHED TCP to the model backend 8.7x past the 1800s floor). PGID membership does
+  # not change on reparenting, so a negative-PGID kill reaches it wherever it lands.
+  # `set -m` makes a backgrounded job a group leader portably — macOS ships no `setsid` —
+  # and the prior monitor state is restored so job control never leaks into the caller.
+  # Same pattern as _fleet_name_model's bounded helper. The PGID is only acted on by
+  # _kill_process_group (via _kill_job), which re-validates it is a real group and NOT
+  # this shell's own, and falls back to a tree walk when isolation did not take; a
+  # mis-recorded value therefore degrades to the old behaviour instead of mis-killing.
+  local _mon=0; case "$-" in *m*) _mon=1 ;; esac
+  [ "$_mon" = 1 ] || set -m
   ( exec "$@" </dev/null >> "$jd/out.log" 2>&1 ) &
-  local pid=$! t0 last_size=0 last_change now size idle age _jcwd=""
+  local pid=$! _pgid="" _shell_pgid=""
+  _pgid="$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d ' ')"
+  [ "$_mon" = 1 ] || set +m
+  case "$_pgid" in ''|*[!0-9]*) _pgid="" ;; esac
+  _shell_pgid="$(ps -o pgid= -p "$$" 2>/dev/null | tr -d ' ')"
+  case "$_shell_pgid" in ''|*[!0-9]*) _shell_pgid="" ;; esac
+  # Record the PGID only when it is a genuine isolated group (>1 and not our own), so the
+  # file's presence means "kill this group" and a failed isolation leaves it absent and
+  # _kill_job falls back to the tree walk instead of signalling the supervisor's group.
+  if [ -n "$_pgid" ] && [ "$_pgid" -gt 1 ] 2>/dev/null && [ "$_pgid" != "$_shell_pgid" ]; then
+    printf '%s\n' "$_pgid" > "$jd/pgid" 2>/dev/null || true
+  fi
+  local t0 last_size=0 last_change now size idle age _jcwd=""
   t0=$(date +%s); last_change=$t0
   echo "$pid" > "$jd/pid"
   # Persist the SUPERVISOR's own pid + start-time too. If this watchdog process is killed
@@ -6311,7 +6391,7 @@ _supervise() {
   local _stime; _stime="$(ps -o lstart= -p "$pid" 2>/dev/null | tr -s ' ' || printf '%s' "$t0")"
   printf '%s\n' "$_stime" > "$jd/pid_start"
   # Signal trap: kill the delegate tree if the supervisor is signaled.
-  trap '_kill_tree "$pid"; echo interrupted > "$jd/status"; printf "interrupted:signal\n" > "$jd/reason" 2>/dev/null || true; exit 130' TERM INT
+  trap '_kill_job "$jd" "$pid"; echo interrupted > "$jd/status"; printf "interrupted:signal\n" > "$jd/reason" 2>/dev/null || true; exit 130' TERM INT
   # Exploration-spiral guard: a mutating verb that reads/greps forever grows the log, so the
   # byte-growth timer never trips. Track WRITES too. First expose "exploring?" so it can be steered;
   # if it then remains both write-free AND output-silent for another bounded window, stop it as a
@@ -6378,7 +6458,7 @@ _supervise() {
       echo wedged > "$jd/status"
       printf '%s\n' "$_noinit_reason" > "$jd/reason" 2>/dev/null || true
       echo "[outsourcerer] job $(basename "$jd"): $_noinit_reason" >&2
-      _kill_tree "$pid"; echo 125 > "$jd/exit"; return 125
+      _kill_job "$jd" "$pid"; echo 125 > "$jd/exit"; return 125
     fi
     if [ "$mutating" = "1" ] && [ "$age" -ge "$nww" ] && [ "$(cat "$jd/status" 2>/dev/null)" = "running" ]; then
       _job_made_writes "$jd" "$_jcwd" || {
@@ -6394,7 +6474,7 @@ _supervise() {
       echo wedged > "$jd/status"
       printf 'exploring-timeout\n' > "$jd/reason" 2>/dev/null || true
       echo "[outsourcerer] job $(basename "$jd") stayed in exploring? for ${nww_kill}s with ZERO file writes and no output growth; stopped as stalled. Re-run with a tighter write target if more exploration is genuinely needed." >&2
-      _kill_tree "$pid"; echo 125 > "$jd/exit"; return 125
+      _kill_job "$jd" "$pid"; echo 125 > "$jd/exit"; return 125
     fi
     # SELF-HEAL backstop (LANE-AGNOSTIC): a mutating job hitting repeated permission/sandbox denials is
     # walled off — headless delegates (claude/codex/devin/local) cannot answer an interactive prompt, so it
@@ -6406,7 +6486,7 @@ _supervise() {
         echo "permission-blocked" > "$jd/status"
         printf 'permission-blocked:denials=%s\n' "$_pd" > "$jd/reason" 2>/dev/null || true
         echo "[outsourcerer] ABORT job $(basename "$jd"): $_pd permission/sandbox denials — the delegate is walled off (a protected path or sandbox that can't be auto-approved headless). Re-run with 'yolo' (bypassPermissions), from a different cwd, or with the right sandbox/--add-dir." >&2
-        _kill_tree "$pid"; echo 3 > "$jd/exit"; return 3
+        _kill_job "$jd" "$pid"; echo 3 > "$jd/exit"; return 3
       fi
     fi
     # DEVIN PRINT-MODE HANG (LANE-AGNOSTIC, immediate): a headless devin (`-p` / print mode) that
@@ -6439,11 +6519,11 @@ _supervise() {
         echo "permission-blocked" > "$jd/status"
         printf 'permission-blocked:print-mode-hang\n' > "$jd/reason" 2>/dev/null || true
         echo "[outsourcerer] ABORT job $(basename "$jd"): devin print-mode rejected a tool exec that requires confirmation — a headless delegate cannot prompt, so it will hang silently. Re-run with 'yolo' (bypassPermissions), or restructure the prompt so the delegate ends on a file write (move validation/commit/PR creation to the orchestrator)." >&2
-        _kill_tree "$pid"; echo 3 > "$jd/exit"; return 3
+        _kill_job "$jd" "$pid"; echo 3 > "$jd/exit"; return 3
       fi
     fi
     if [ "$age" -ge "$hard" ]; then
-      echo timeout > "$jd/status"; printf 'hard-timeout:%ss\n' "$hard" > "$jd/reason" 2>/dev/null || true; _kill_tree "$pid"; echo 124 > "$jd/exit"; return 124
+      echo timeout > "$jd/status"; printf 'hard-timeout:%ss\n' "$hard" > "$jd/reason" 2>/dev/null || true; _kill_job "$jd" "$pid"; echo 124 > "$jd/exit"; return 124
     fi
     # Before declaring a stall, look for progress the LOG cannot show. A delegate that prints nothing
     # while writing files is working, and killing it is the failure this watchdog causes rather than
@@ -6509,7 +6589,7 @@ _supervise() {
         # `explain`/`status` can show it instead of a bare `wedged` verdict.
         printf 'stall-kill\n' > "$jd/reason" 2>/dev/null || true
       fi
-      _kill_tree "$pid"; echo 125 > "$jd/exit"; return 125
+      _kill_job "$jd" "$pid"; echo 125 > "$jd/exit"; return 125
     fi
     if [ "$idle" -ge "$warn" ] && [ "$(cat "$jd/status" 2>/dev/null)" = "running" ]; then
       echo "stalled?" > "$jd/status"
@@ -8027,7 +8107,7 @@ cmd_cancel() {
   local id="${1:-}"; [ -n "$id" ] || die "cancel needs a job id"
   local jd="$OSRC_JOBS/$id"; [ -d "$jd" ] || die "no such job: $id"
   local pid; pid="$(cat "$jd/pid" 2>/dev/null)"
-  [ -n "$pid" ] && _kill_tree "$pid"
+  [ -n "$pid" ] && _kill_job "$jd" "$pid"
   echo canceled > "$jd/status"; printf 'canceled:operator\n' > "$jd/reason" 2>/dev/null || true; echo "canceled $id"
   # DISCLOSED limitation: Cline runs a hub/spoke topology and can detach spoke processes that live
   # outside this job's process tree, so _kill_tree may not reach them. A full process-group kill of
@@ -8056,7 +8136,7 @@ cmd_cleanup() {
   # Cleanup can race a live supervisor (or recover after one was killed).  Stop the delegate's
   # complete tree before removing its worktree so grandchildren cannot survive as poisoned orphans.
   local live_pid; live_pid="$(cat "$OSRC_JOBS/$target/pid" 2>/dev/null)"
-  [ -n "$live_pid" ] && _kill_tree "$live_pid"
+  [ -n "$live_pid" ] && _kill_job "$OSRC_JOBS/$target" "$live_pid"
   local wj="$OSRC_JOBS/$target/worktree.json"
   [ -f "$wj" ] || wj="$OSRC_HOME/loops/$target/worktree.json"
   [ -f "$wj" ] || { echo "[outsourcerer] $target has no worktree to clean."; return 0; }

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/conformance.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/conformance.sh
@@ -66,6 +66,7 @@ _ALL_SUITES="$_ALL_SUITES test_value_router"
 _ALL_SUITES="$_ALL_SUITES test_advise_dynamic_pool"
 _ALL_SUITES="$_ALL_SUITES test_bg_provider_after_verb"
 _ALL_SUITES="$_ALL_SUITES test_quota"
+_ALL_SUITES="$_ALL_SUITES test_supervise_pgroup_kill"
 for t in $_ALL_SUITES; do
   if [ -f "$SCRIPT_DIR/$t.sh" ]; then
     # Capture rather than discard: a failing suite whose output went to /dev/null makes a CI log say

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_supervise_pgroup_kill.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_supervise_pgroup_kill.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+# test_supervise_pgroup_kill.sh — the _supervise watchdog must actually REAP a wedged
+# delegate whose grandchild ignores SIGTERM and re-parents to PID 1 when its parent dies.
+#
+# Root cause this guards: _supervise launched its delegate in the supervisor's own
+# process group and tore the tree down with _kill_tree, which walks via ppid
+# (_descendants / pgrep -P) and re-snapshots AFTER the TERM pass to decide what to
+# SIGKILL. A grandchild immune to SIGTERM survives the TERM pass; its parent dies on
+# TERM; the grandchild re-parents to PID 1 and leaves the tree; the KILL pass's second
+# _descendants snapshot never re-discovers it — so it keeps its inherited socket/file
+# and the stall-kill floor never reaps. Incident (2026-08-24): a wedged `devin acp`
+# held an ESTABLISHED TCP to the model backend for 4h21m (15,660s), 8.7x past the 1800s
+# devin stall-kill floor, while the watchdog believed it had killed the job.
+#
+# Fix under test: _supervise launches the delegate as its own process-group leader
+# (set -m, portable — macOS ships no setsid) and records the PGID in <job-dir>/pgid;
+# _kill_job kills the whole group by negative PGID (TERM -> grace -> KILL), which
+# reaches every member regardless of reparenting, since PGID membership does not change
+# when a process is re-parented. SIGKILL on the group cannot be caught, so a grandchild
+# that ignored SIGTERM still dies.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Honor an override so the same test can be run against an unpatched source to prove it
+# catches the regression, without mutating the working tree.
+SRC="${OSRC_TEST_SRC:-$SCRIPT_DIR/../outsourcerer.sh}"
+[ -f "$SRC" ] || { echo "FAIL: cannot find $SRC"; exit 1; }
+bash -n "$SRC" || { echo "FAIL: bash -n failed for $SRC"; exit 1; }
+
+TMP="$(mktemp -d)"
+export OSRC_HOME="$TMP"
+export HOME="$TMP"
+_REAP_PIDS=""
+cleanup() {
+  # Never leak a wedged `sleep 600` grandchild if an assertion aborts mid-run.
+  [ -n "$_REAP_PIDS" ] && kill -KILL $_REAP_PIDS 2>/dev/null || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+pass=0; fail=0
+ok()  { echo "PASS: $1"; pass=$((pass+1)); }
+bad() { echo "FAIL: $1"; fail=$((fail+1)); }
+
+# Clear argv before sourcing: the engine dispatches on "$@", so any argument passed to
+# this test would be interpreted as a subcommand and could abort the suite mid-run.
+set --
+. "$SRC" >/dev/null 2>&1
+# Re-arm AFTER sourcing: the engine installs its own EXIT trap, which replaces this one
+# and would leak the temp dir (and any wedged grandchild) per run.
+trap cleanup EXIT
+
+for fn in _kill_tree _kill_process_group _supervise; do
+  type "$fn" >/dev/null 2>&1 || { echo "FAIL: $fn not defined"; exit 1; }
+done
+# _kill_job is the fix's helper; it is absent in the unpatched source. The source-level
+# check below reports its absence as a FAIL, but the runtime wedge test must still run
+# so the surviving-grandchild regression is demonstrated against the old code too.
+_have_kill_job=0; type _kill_job >/dev/null 2>&1 && _have_kill_job=1
+
+# A process is gone once it no longer exists OR is a zombie awaiting reaping. kill -0 is
+# true for a zombie, so the state must be checked too. Used for the grandchild liveness
+# assertion that is the heart of this test.
+_proc_gone() {   # <pid> -> 0 if dead/gone/zombie
+  local p="$1" st
+  kill -0 "$p" 2>/dev/null || return 0
+  st="$(ps -o stat= -p "$p" 2>/dev/null | tr -d '[:space:]')"
+  case "$st" in ''|Z*) return 0 ;; esac
+  return 1
+}
+
+# Poll for reaping: launchd/init reaps an orphaned zombie asynchronously, so a SIGKILL'd
+# grandchild can read as a live zombie for a fraction of a second before it vanishes.
+# Wait briefly for that reap before declaring it a survivor.
+_wait_gone() {   # <pid> -> 0 if gone within ~2s, 1 if still live
+  local p="$1" i
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    _proc_gone "$p" && return 0
+    sleep 0.2
+  done
+  return 1
+}
+
+# ------------------------------------------------------------- SOURCE-LEVEL
+# _kill_job exists and routes through the process-group killer (with a tree-walk
+# fallback for job dirs that have no isolated PGID on record).
+if [ "$_have_kill_job" = "1" ] && grep -aqE '^_kill_job\(\)' "$SRC"; then
+  ok "source: _kill_job helper is defined"
+else
+  bad "source: _kill_job helper missing"
+fi
+# Capture function bodies in variables rather than piping awk -> grep: under
+# `set -o pipefail`, `grep -q` closing the pipe early sends SIGPIPE to awk (rc=141),
+# which makes the pipeline fail even when the pattern IS present.
+_killjob_body="$(awk '/^_kill_job\(\)/{f=1} f{print} f&&/^}/{exit}' "$SRC" 2>/dev/null)"
+printf '%s' "$_killjob_body" | grep -q _kill_process_group \
+  && ok "source: _kill_job routes through _kill_process_group" \
+  || bad "source: _kill_job does not call _kill_process_group"
+# _supervise records an isolated PGID for the job and uses _kill_job on every exit arm.
+_supervise_body="$(awk '/^_supervise\(\)/{f=1} f{print} f&&/^}/{exit}' "$SRC" 2>/dev/null)"
+printf '%s' "$_supervise_body" | grep -aq '\$jd/pgid' \
+  && ok "source: _supervise records the delegate PGID in \$jd/pgid" \
+  || bad "source: _supervise does not record a job PGID"
+printf '%s' "$_supervise_body" | grep -aq '_kill_job "\$jd" "\$pid"' \
+  && ok "source: _supervise tear-down uses _kill_job (not a bare _kill_tree)" \
+  || bad "source: _supervise still tears down with _kill_tree directly"
+# The portable isolation primitive is `set -m`, not setsid (macOS ships none).
+printf '%s' "$_supervise_body" | grep -aq 'set -m' \
+  && ok "source: _supervise isolates the delegate via set -m (portable, no setsid)" \
+  || bad "source: _supervise does not use set -m for process-group isolation"
+# No _kill_tree "$pid" should remain inside _supervise (the whole point of the fix).
+if printf '%s' "$_supervise_body" | grep -aq '_kill_tree "\$pid"'; then
+  bad "source: a direct _kill_tree \"\$pid\" survives inside _supervise — kill can still miss the grandchild"
+else
+  ok "source: no direct _kill_tree \"\$pid\" remains inside _supervise"
+fi
+
+# --------------------------------------------- WEDGE: TERM-immune grandchild
+# The delegate spawns a grandchild that IGNORES SIGTERM/INT and outlives its parent,
+# then parks on `wait`. The delegate itself dies on SIGTERM (default disposition), which
+# orphans the grandchild to PID 1 — exactly the incident's `devin -p` -> `devin acp`
+# shape. Only a process-group SIGKILL can reach the grandchild once it has re-parented
+# out of the ppid tree. The grandchild records its own pid, pgid, and start time so the
+# assertion can distinguish "our grandchild, still alive" from a recycled PID.
+GRANDCHILD="$TMP/wedge-grandchild.sh"
+cat > "$GRANDCHILD" <<'EOF'
+#!/usr/bin/env bash
+# A wedged backend holder: ignore the graceful signals a tree walk sends first, write
+# identifying state, then hold a pretend socket forever. SIGKILL is the only way out.
+trap '' TERM
+trap '' INT
+gp="$1"; gg="$2"; gs="$3"
+printf '%s\n' "$$" > "$gp"
+printf '%s\n' "$(ps -o pgid= -p "$$" 2>/dev/null | tr -d '[:space:]')" > "$gg"
+ps -o lstart= -p "$$" 2>/dev/null | tr -s ' ' > "$gs"
+sleep 600
+EOF
+chmod +x "$GRANDCHILD"
+
+FAKE_WEDGE="$TMP/fake-wedge.sh"
+cat > "$FAKE_WEDGE" <<EOF
+#!/usr/bin/env bash
+# The delegate: fork the wedged grandchild, then block on wait. Emits NOTHING to stdout
+# so the byte-growth watchdog sees a stall and fires the kill floor.
+"$GRANDCHILD" "$TMP/wedge.pid" "$TMP/wedge.pgid" "$TMP/wedge.start" &
+wait
+EOF
+chmod +x "$FAKE_WEDGE"
+
+jd="$TMP/jobs/wedge"
+mkdir -p -m 700 "$jd"; echo '{"verb":"run"}' > "$jd/meta.json"
+rm -f "$TMP/wedge.pid" "$TMP/wedge.pgid" "$TMP/wedge.start"
+# warn=2 / kill=3 / hard=60. Disable the filesystem-progress and devin-log liveness
+# resets so a foreign file write (or a devin log dir) cannot prop up idle and prevent
+# the stall-kill from firing — the test must reach the kill deterministically.
+OSRC_POLL=1 OSRC_FS_PROGRESS=0 OSRC_DEVIN_LIVENESS=0 _supervise "$jd" 2 3 60 -- "$FAKE_WEDGE" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 125 ]; then
+  ok "wedge: stall-kill fired (exit 125, wedged)"
+else
+  bad "wedge: expected exit 125 (wedged/stall-kill), got $rc"
+fi
+
+gp="$(cat "$TMP/wedge.pid" 2>/dev/null | tr -d '[:space:]')"
+gc_pgid="$(cat "$TMP/wedge.pgid" 2>/dev/null | tr -d '[:space:]')"
+gstart="$(cat "$TMP/wedge.start" 2>/dev/null | tr -s ' ')"
+[ -n "$gp" ] && _REAP_PIDS="$_REAP_PIDS $gp"
+
+# The grandchild must have shared the job's isolated process group — that is the
+# invariant that makes a negative-PGID kill reach it after it re-parents.
+job_pgid="$(cat "$jd/pgid" 2>/dev/null | tr -d '[:space:]')"
+if [ -n "$job_pgid" ] && [ -n "$gc_pgid" ] && [ "$job_pgid" = "$gc_pgid" ]; then
+  ok "wedge: grandchild shared the job's process group (pgid=$gc_pgid) — PG kill can reach it"
+else
+  bad "wedge: grandchild pgid=${gc_pgid:-<none>} != job pgid=${job_pgid:-<none>} — the grandchild was NOT in the isolated group"
+fi
+
+if [ -z "$gp" ]; then
+  bad "wedge: grandchild never wrote its pid (test setup did not run it)"
+elif _wait_gone "$gp"; then
+  # Rule out PID reuse: only call it dead if the live process (if any) is NOT our
+  # grandchild. A recycled PID will have a different start time and a different pgid.
+  live_start="$(ps -o lstart= -p "$gp" 2>/dev/null | tr -s ' ')"
+  live_pgid="$(ps -o pgid= -p "$gp" 2>/dev/null | tr -d '[:space:]')"
+  if [ -n "$gstart" ] && [ -n "$live_start" ] && [ "$live_start" = "$gstart" ] && [ "$live_pgid" = "$gc_pgid" ]; then
+    bad "wedge: PID $gp matches our grandchild's start/pgid yet reads live — SIGKILL did not take (REGRESSION)"
+  else
+    ok "wedge: grandchild was reaped (gone or PID recycled) — process-group SIGKILL reached the re-parented grandchild"
+  fi
+else
+  # Still live AND it is genuinely our grandchild (same start time + pgid): the kill
+  # missed it. This is the watchdog bug, reproduced. When ps -o lstart= is unavailable
+  # (busybox/Alpine/MSYS), gstart is empty and we CANNOT distinguish our grandchild
+  # from a recycled PID — fail conservatively rather than false-pass, since this is a
+  # regression test and a false-pass is worse than a false-fail.
+  live_start="$(ps -o lstart= -p "$gp" 2>/dev/null | tr -s ' ')"
+  if [ -z "$gstart" ]; then
+    bad "wedge: grandchild PID $gp still ALIVE after the kill floor, but ps -o lstart= is unavailable for identity check — cannot confirm reap (fail conservative)"
+  elif [ "$live_start" = "$gstart" ]; then
+    bad "wedge: grandchild PID $gp still ALIVE after the kill floor — the re-parented grandchild escaped the tree walk (REGRESSION of the watchdog bug)"
+  else
+    ok "wedge: PID $gp now belongs to another process (start mismatch) — our grandchild was reaped"
+  fi
+fi
+
+# ----------------------------------- COOPERATIVE grandchild: graceful TERM path
+# Prove the fix did not remove the graceful SIGTERM step. A grandchild that HONORS TERM
+# must exit on the TERM pass (recording that it received it), so the KILL pass is a
+# no-op rather than the thing that stops it. Otherwise an over-eager KILL-only path
+# would tear down a cooperative delegate that could have cleaned up.
+COOP_GC="$TMP/coop-grandchild.sh"
+cat > "$COOP_GC" <<'EOF'
+#!/usr/bin/env bash
+trap 'printf term-received > "'"$1"'"; exit 0' TERM
+trap '' INT
+printf '%s\n' "$$" > "$2"
+sleep 600
+EOF
+chmod +x "$COOP_GC"
+
+FAKE_COOP="$TMP/fake-coop.sh"
+cat > "$FAKE_COOP" <<EOF
+#!/usr/bin/env bash
+"$COOP_GC" "$TMP/coop.term" "$TMP/coop.pid" &
+wait
+EOF
+chmod +x "$FAKE_COOP"
+
+jd2="$TMP/jobs/coop"
+mkdir -p -m 700 "$jd2"; echo '{"verb":"run"}' > "$jd2/meta.json"
+rm -f "$TMP/coop.term" "$TMP/coop.pid"
+OSRC_POLL=1 OSRC_FS_PROGRESS=0 OSRC_DEVIN_LIVENESS=0 _supervise "$jd2" 2 3 60 -- "$FAKE_COOP" >/dev/null 2>&1
+rc2=$?
+[ "$rc2" -eq 125 ] && ok "coop: cooperative wedged delegate still stopped with exit 125" \
+                    || bad "coop: expected exit 125 for a silent cooperative delegate, got $rc2"
+cpid="$(cat "$TMP/coop.pid" 2>/dev/null | tr -d '[:space:]')"
+[ -n "$cpid" ] && _REAP_PIDS="$_REAP_PIDS $cpid"
+if [ -f "$TMP/coop.term" ]; then
+  ok "coop: grandchild received SIGTERM and exited gracefully (graceful path intact, no SIGKILL needed)"
+else
+  bad "coop: grandchild never received SIGTERM — the graceful TERM step was lost (KILL-only regression)"
+fi
+if [ -n "$cpid" ] && _wait_gone "$cpid"; then
+  ok "coop: cooperative grandchild is gone after the kill"
+else
+  bad "coop: cooperative grandchild PID ${cpid:-<none>} still alive — kill did not complete"
+fi
+
+# ------------------------------------------- NORMAL FINISH: no false positive
+# A delegate that finishes cleanly with no grandchild must keep its real exit code and
+# never be killed by the watchdog. Guards against an over-broad change that kills every
+# job's group on exit.
+FAKE_OK="$TMP/fake-ok.sh"
+cat > "$FAKE_OK" <<'EOF'
+#!/usr/bin/env bash
+echo "OSRC::DONE"
+echo "work completed normally"
+exit 0
+EOF
+chmod +x "$FAKE_OK"
+
+jd3="$TMP/jobs/normal"
+mkdir -p -m 700 "$jd3"; echo '{"verb":"run"}' > "$jd3/meta.json"
+OSRC_POLL=1 _supervise "$jd3" 5 60 120 -- "$FAKE_OK" >/dev/null 2>&1
+rc3=$?
+status3="$(cat "$jd3/status" 2>/dev/null)"
+if [ "$rc3" -eq 0 ]; then
+  ok "normal: clean-finishing delegate keeps exit 0 (not false-killed)"
+else
+  bad "normal: expected exit 0 for a clean finish, got $rc3 (status=$status3)"
+fi
+case "$status3" in
+  done|done?) ok "normal: clean finish not marked wedged/timed-out (status=$status3)" ;;
+  *)          bad "normal: clean finish wrongly marked '$status3'" ;;
+esac
+
+echo
+echo "RESULT: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What happened

A `devin -m glm-5-2 -p` review job was spawned via `__runjob` with a ~116KB diff + 2.25KB
prompt. GLM's backend accepted the TCP connection then went silent — no data, no RST, no
error. Three processes stayed alive for **4h21m (15,660s)**, 8.7x past the devin stall-kill
floor (`OSRC_DEVIN_STALL_KILL`, default 1800s = 30 min):

- PID 25374 — `outsourcerer.sh __runjob` (wrapper, 0% CPU)
- PID 30310 — `devin -m glm-5-2 -p` (child, 0% CPU)
- PID 30318 — `devin acp` (grandchild, holding the ESTABLISHED TCP to the GLM backend)

The expected output file was never written. The watchdog believed it had killed the job.
It hadn't.

## Root cause

`_kill_tree` walks the process tree via ppid (`pgrep -P` / `ps -o ppid=`), sends SIGTERM
to all descendants deepest-first, sleeps 2s, then re-snapshots the tree and sends SIGKILL
to anything still standing. The escalation to SIGKILL is already there — the problem is
that the second snapshot can't see the target.

Here's the exact sequence:

1. The watchdog fires the stall-kill and calls `_kill_tree` on the delegate PID.
2. SIGTERM reaches the whole tree. `devin -p` (the child) dies — TERM is its default
   disposition.
3. `devin acp` (the grandchild) **ignores SIGTERM** and survives.
4. With its parent gone, `devin acp` is re-parented to PID 1. It's now outside the ppid
   tree — `_descendants` walks via `pgrep -P`, and nothing has `devin acp` as a child
   anymore.
5. The KILL pass re-snapshots the tree. `devin acp` is not in it. SIGKILL never reaches it.
6. The grandchild keeps its inherited TCP socket to the model backend. The job never
   returns.

The existing comment at `_timeout` (lines 539-543) already identifies that killing only
the direct child leaves grandchildren running, and claims `_kill_tree`'s deepest-first
walk solves it. The incident proves it does not solve the case where the grandchild
survives the TERM pass and re-parents before the KILL pass re-snapshots.

## The fix

Two changes, both in `_supervise` and its kill path:

**1. Launch the delegate in its own process group.** `_supervise` now brackets the
delegate launch with `set -m` / `set +m` (saving and restoring the prior monitor state),
which makes the backgrounded subshell its own process-group leader — the same portable
pattern `_fleet_name_model` already uses for bounded helper cleanup (macOS ships no
`setsid`). The PGID is recorded in `<job-dir>/pgid`, but only when it's a genuine
isolated group (> 1 and not the supervisor's own), so a failed isolation leaves the file
absent and the kill path falls back to the tree walk instead of signalling the wrong
group.

**2. Kill the process group, not the tree.** A new `_kill_job` helper reads the recorded
PGID and calls the existing `_kill_process_group`, which does `kill -TERM -- -PGID` → 2s
grace → `kill -KILL -- -PGID` → survivor check. All 7 kill sites inside `_supervise` (the
signal trap, no-init, exploring-timeout, permission-blocked ×2, hard-timeout, stall-kill)
plus `cmd_cancel` and `cmd_cleanup` now call `_kill_job` instead of `_kill_tree`.

**Why this works:** process-group membership is set at `setpgid` time and does not change
when a process is re-parented. `kill -- -PGID` reaches every member of the group regardless
of where it sits in the process tree, so a grandchild that re-parented to PID 1 is still
reachable. SIGKILL on the group cannot be caught, so a grandchild that ignored SIGTERM
still dies.

**Stale-PGID guard:** before killing the group, `_kill_job` re-validates that the root
PID is still alive and its current PGID still matches the recorded one. `cmd_cleanup` can
run days after the job finished — without this check, a recycled PGID could kill an
unrelated process group. If the PID is dead, has a different PGID, or `ps` is unavailable,
the kill falls back to the tree walk (harmless on a dead PID).

**Survivor reporting:** when `_kill_process_group` reports live members after the KILL
pass, `_kill_job` records `kill-survivors-remain` in `<job-dir>/reason`. The prior code
discarded this signal at every call site — the watchdog believed it had reaped the job
whether or not survivors remained, which is exactly the incident pattern. Now a recurrence
is loud instead of silent.

**Fallback:** when no PGID is recorded (an old job dir from before this fix, or a platform
where `ps -o pgid=` didn't return a usable value), `_kill_job` falls back to `_kill_tree` —
the prior behavior. The fix never makes things worse than they were.

## Known limitation

If a delegate child or grandchild calls `setsid()` to create a new session, it leaves the
job's process group entirely and the negative-PGID kill cannot reach it. This is a
different escape mechanism than the reparenting bug this fix addresses. The survivor
check now reports any remaining group members loudly, so a partial escape is at least
visible. Confirming whether `devin acp` uses `setsid()` requires inspecting a live `devin`
process tree, which I could not do from this environment.

## What's NOT changed

The same bug class exists in `_fg_guard` (foreground watchdog) and `_fallback_dispatch`
(fallback pipeline), which also call `_kill_tree` directly. These are the foreground /
interactive paths, not the background supervised path where the incident occurred. They
use a different launch mechanism (fifo/tee pipeline) and are mutually exclusive with
`_supervise`. Fixing them is the same pattern but a different launch site, so it's left
as follow-up rather than expanding this change.

`_timeout` (bounded helper) and `_loop_check` (acceptance check) also use `_kill_tree`,
but their process trees are shallow — short CLI calls, not deep delegate trees with
grandchildren holding sockets. Not affected.

## Test

New `tests/test_supervise_pgroup_kill.sh` (14 assertions, 4 scenarios), registered in
the conformance gate:

- **Source-level**: `_kill_job` exists and routes through `_kill_process_group`; `_supervise`
  records a PGID and uses `_kill_job` on every exit arm; isolation uses `set -m` (not
  `setsid`); no direct `_kill_tree "$pid"` remains inside `_supervise`.
- **Wedge**: a delegate spawns a grandchild that ignores SIGTERM/INT and outlives its
  parent (the incident's `devin -p` → `devin acp` shape). Asserts the grandchild is reaped
  via process-group SIGKILL after re-parenting, using start-time + PGID to distinguish our
  grandchild from a recycled PID. Fails conservatively when `ps -o lstart=` is unavailable.
- **Cooperative**: a grandchild that honors SIGTERM exits gracefully on the TERM pass —
  proves the graceful step was not removed in favor of KILL-only.
- **Normal**: a clean-finishing delegate keeps exit 0 — proves no false positive.

Verified to fail on the unpatched source (grandchild survives — "REGRESSION of the
watchdog bug") and pass on the patched source (14/14). Existing tests
(`test_devin_printmode_hang`, `test_windows_portability`, `test_job_lifecycle`,
`test_hardening`, `test_devin_liveness`) all still pass.
