### PR TITLE
fix(--with): reject unrecognized spec at parse time instead of silently dropping it

### DIFF
--- a/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
@@ -2049,17 +2049,27 @@ _resolve_skill_file() {
   return 1
 }
 
-# _validate_with_token <tok> -> die unless tok is a recognized --with form (skills=... | mcp=...).
+# _validate_with_token <arg> -> die unless every whitespace-separated token in <arg> is a
+# recognized --with form (skills=<names> | mcp=<names>, both requiring a non-empty value).
 # A non-empty but unrecognized spec (e.g. a bare file path someone passes expecting file-attach)
 # used to be stored into WITH_SPEC and then silently dropped during capability injection: only
 # skills= and mcp= are honored there, so the delegate ran with none of the intended context and
 # nothing told the caller. Reject unrecognized forms at parse time so the footgun is loud, not
 # silent. The empty-arg die at each parse site stays; this adds the non-empty-but-bad die.
+#
+# WITH_SPEC is space-delimited and iterated unquoted at injection time (for tok in $WITH_SPEC),
+# so a single --with argument containing whitespace (e.g. "skills=a,b /tmp/brief.txt") is split
+# into multiple tokens. Validating only the prefix would let an invalid trailing token pass and
+# still silently drop at injection — the exact footgun this fixes. Validate EVERY token. Also
+# reject empty values (skills= / mcp=) since those are silent no-ops of the same class.
 _validate_with_token() {
-  case "$1" in
-    skills=*|mcp=*) return 0 ;;
-    *) die "--with requires e.g. skills=a,b or mcp=x (got '$1'); an unrecognized spec is rejected rather than silently dropped" ;;
-  esac
+  local tok
+  for tok in ${1:-}; do
+    case "$tok" in
+      skills=?*|mcp=?*) ;;
+      *) die "--with requires e.g. skills=a,b or mcp=x (got '$tok'); an unrecognized spec is rejected rather than silently dropped" ;;
+    esac
+  done
 }
 
 build_with_preamble() {
@@ -10585,6 +10595,10 @@ _secret_scan() {
   fi
   fi
   # (2) best-effort pattern scan over prompt + --with files (report only, never hard-blocks).
+  # After _validate_with_token (parse time), every WITH_SPEC token is a skills=… or mcp=… form,
+  # so the `*=*) continue` branch always fires and the bare-file `[ -f "$tok" ]` path below is
+  # now unreachable. Kept as defensive coverage in case a future code path sets WITH_SPEC without
+  # going through the parse-site validators.
   if [ -n "${WITH_SPEC:-}" ]; then
     local tok; local -a _ws; IFS=' ' read -ra _ws <<< "$WITH_SPEC"
     for tok in "${_ws[@]}"; do

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
@@ -802,7 +802,7 @@ parse_model() {
     case "$1" in
       -m|--model)           [ -n "${2:-}" ] || die "-m requires a model name"; MODEL="$2"; MODEL_EXPLICIT=1; shift 2 ;;
       --tier)               [ -n "${2:-}" ] || die "--tier requires: frontier|capable|mid|budget|raw"; TIER_FLAG="$2"; OSRC_TIER_OVERRIDE="$2"; shift 2 ;;
-      --with)               [ -n "${2:-}" ] || die "--with requires e.g. skills=a,b or mcp=x"; WITH_SPEC="$WITH_SPEC $2"; shift 2 ;;
+      --with)               [ -n "${2:-}" ] || die "--with requires e.g. skills=a,b or mcp=x"; _validate_with_token "$2"; WITH_SPEC="$WITH_SPEC $2"; shift 2 ;;
       --effort|--reasoning) [ -n "${2:-}" ] || die "--effort requires: minimal|low|medium|high|xhigh|max"
                             case "$2" in minimal|low|medium|high|xhigh|max|none) EFFORT="$2" ;;
                               *) die "--effort '$2' invalid (use: minimal|low|medium|high|xhigh|max)" ;; esac
@@ -2049,6 +2049,19 @@ _resolve_skill_file() {
   return 1
 }
 
+# _validate_with_token <tok> -> die unless tok is a recognized --with form (skills=... | mcp=...).
+# A non-empty but unrecognized spec (e.g. a bare file path someone passes expecting file-attach)
+# used to be stored into WITH_SPEC and then silently dropped during capability injection: only
+# skills= and mcp= are honored there, so the delegate ran with none of the intended context and
+# nothing told the caller. Reject unrecognized forms at parse time so the footgun is loud, not
+# silent. The empty-arg die at each parse site stays; this adds the non-empty-but-bad die.
+_validate_with_token() {
+  case "$1" in
+    skills=*|mcp=*) return 0 ;;
+    *) die "--with requires e.g. skills=a,b or mcp=x (got '$1'); an unrecognized spec is rejected rather than silently dropped" ;;
+  esac
+}
+
 build_with_preamble() {
   [ -n "${WITH_SPEC:-}" ] || return 0
   local tok val name f out=""
@@ -2224,7 +2237,7 @@ _consume_flags() {
     case "$1" in
       -m|--model) [ -n "${2:-}" ] || die "-m requires a model name"; MODEL="$2"; MODEL_EXPLICIT=1; shift 2 ;;
       --tier)     [ -n "${2:-}" ] || die "--tier requires: frontier|capable|mid|budget|raw"; TIER_FLAG="$2"; OSRC_TIER_OVERRIDE="$2"; shift 2 ;;
-      --with)     [ -n "${2:-}" ] || die "--with requires e.g. skills=a,b or mcp=x"; WITH_SPEC="$WITH_SPEC $2"; shift 2 ;;
+      --with)     [ -n "${2:-}" ] || die "--with requires e.g. skills=a,b or mcp=x"; _validate_with_token "$2"; WITH_SPEC="$WITH_SPEC $2"; shift 2 ;;
       --allow-downgrade) OSRC_ALLOW_DOWNGRADE=1; shift ;;
       --no-advise) OSRC_NO_ADVISE=1; shift ;;   # opt out of auto-advise model selection on a bare run
       --cloud-ack) OSRC_CLOUD_ACK=1; shift ;;   # consume as a LEADING flag: sets the cloud-gate ack and never leaks into REST/prompt
@@ -8942,7 +8955,7 @@ cmd_fanout() {
       --task)         [ -n "${2:-}" ] || die "--task needs a string"; taskstr="$2"; shift 2 ;;
       --route)        [ -n "${2:-}" ] || die "--route needs 'pattern=model,...'"; route_spec="$2"; shift 2 ;;
       --worktree)     export OSRC_WORKTREE=1; shift ;;
-      --with)         [ -n "${2:-}" ] || die "--with needs a spec"; fwd+=(--with "$2"); shift 2 ;;
+      --with)         [ -n "${2:-}" ] || die "--with needs a spec"; _validate_with_token "$2"; fwd+=(--with "$2"); shift 2 ;;
       --preamble)     [ -n "${2:-}" ] || die "--preamble needs a file"; preamble="$2"; shift 2 ;;
       --tasks)        [ -n "${2:-}" ] || die "--tasks needs a file"; tasksfile="$2"; shift 2 ;;
       --agents)       [ -n "${2:-}" ] || die "--agents needs a dir"; agentsdir="$2"; shift 2 ;;

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_with_injection.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_with_injection.sh
@@ -25,6 +25,21 @@ bad() { echo "FAIL: $1"; fail=$((fail+1)); }
 . "$SRC" >/dev/null 2>&1
 type -t _resolve_skill_file  >/dev/null || { echo "FAIL: _resolve_skill_file not loaded"; exit 1; }
 type -t build_with_preamble  >/dev/null || { echo "FAIL: build_with_preamble not loaded"; exit 1; }
+type -t _validate_with_token >/dev/null || { echo "FAIL: _validate_with_token not loaded"; exit 1; }
+
+# --- an unrecognized --with spec must be REJECTED at parse time, not silently dropped ----------
+# Only skills= and mcp= are honored at injection time. Anything else (e.g. a bare file path someone
+# passes expecting file-attach) used to be stored and then dropped with NO error and NO warning, so
+# the delegate ran with none of the intended context and nothing told the caller. _validate_with_token
+# makes the footgun loud. die exits the process, so each check runs in a subshell.
+( _validate_with_token "skills=a,b" ) >/dev/null 2>&1 && ok "skills= spec accepted" || bad "skills= spec wrongly rejected"
+( _validate_with_token "mcp=x" )     >/dev/null 2>&1 && ok "mcp= spec accepted"     || bad "mcp= spec wrongly rejected"
+( _validate_with_token "/tmp/brief.txt" ) >/dev/null 2>&1 && bad "a bare file path was accepted (silent no-op returns)" || ok "a bare file path is rejected, not silently dropped"
+( _validate_with_token "attach=/tmp/brief.txt" ) >/dev/null 2>&1 && bad "an unknown form= spec was accepted" || ok "an unrecognized form= spec is rejected"
+# The rejection message must name the spec and point at the valid forms, so the caller can fix it.
+_werr="$( ( _validate_with_token "/tmp/brief.txt" ) 2>&1 >/dev/null )"
+case "$_werr" in *"skills=a,b"*"mcp=x"*"/tmp/brief.txt"*) ok "the rejection names the spec and the valid forms" ;;
+  *) bad "rejection message is missing guidance/spec: $_werr" ;; esac
 
 # --- resolution must cover more than the user's own skills dir ------------------------------------
 # Fixture: a plugin-cache layout and a parity dir, neither of which the old resolver looked at.

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_with_injection.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_with_injection.sh
@@ -41,6 +41,20 @@ _werr="$( ( _validate_with_token "/tmp/brief.txt" ) 2>&1 >/dev/null )"
 case "$_werr" in *"skills=a,b"*"mcp=x"*"/tmp/brief.txt"*) ok "the rejection names the spec and the valid forms" ;;
   *) bad "rejection message is missing guidance/spec: $_werr" ;; esac
 
+# --- empty values (skills= / mcp=) are silent no-ops of the same class — must be rejected -------
+( _validate_with_token "skills=" ) >/dev/null 2>&1 && bad "empty skills= was accepted (silent no-op)" || ok "empty skills= is rejected"
+( _validate_with_token "mcp=" )    >/dev/null 2>&1 && bad "empty mcp= was accepted (silent no-op)"    || ok "empty mcp= is rejected"
+
+# --- whitespace smuggling: a multi-token --with arg with an invalid trailing token -------------
+# WITH_SPEC is space-delimited and iterated unquoted at injection time, so "skills=a,b /tmp/brief.txt"
+# splits into two tokens. Validating only the prefix would let the bare path through and silently drop
+# it at injection — the exact footgun this fix targets. Every token must be validated.
+( _validate_with_token "skills=a,b mcp=x" ) >/dev/null 2>&1 && ok "a multi-token spec with all valid forms is accepted" || bad "a valid multi-token spec was wrongly rejected"
+( _validate_with_token "skills=a,b /tmp/brief.txt" ) >/dev/null 2>&1 && bad "a multi-token spec with an invalid trailing token was accepted" || ok "a multi-token spec with an invalid trailing token is rejected"
+_wsmerr="$( ( _validate_with_token "skills=a,b /tmp/brief.txt" ) 2>&1 >/dev/null )"
+case "$_wsmerr" in *"/tmp/brief.txt"*) ok "the whitespace-smuggling rejection names the bad token, not just the prefix" ;;
+  *) bad "whitespace-smuggling rejection does not name the bad token: $_wsmerr" ;; esac
+
 # --- resolution must cover more than the user's own skills dir ------------------------------------
 # Fixture: a plugin-cache layout and a parity dir, neither of which the old resolver looked at.
 mkdir -p "$TMP/home/.claude/skills/mine" \


### PR DESCRIPTION
## What

`--with` silently ignored anything that wasn't a `skills=…` or `mcp=…` spec. You'd pass `--with /tmp/brief.txt` expecting the delegate to see your brief, the delegate would run with nothing attached, report success, and you'd never know the context never arrived.

## Why this is a footgun

The `--with` flag only rejected an *empty* argument. A non-empty value that didn't match a known form got stored in `WITH_SPEC` and then quietly dropped during capability injection — `build_with_preamble` only handles `skills=`, and `build_mcp_flags_cc` only handles `mcp=`. No error, no warning, exit 0. The delegate ran without the context you briefed it to use, and nothing anywhere said so.

## How to reproduce (before this fix)

```bash
outsourcerer.sh bg explore -m glm --with /tmp/brief.txt "do X per the brief"
```

The delegate reports "no brief attached," exits successfully, and gives you zero signal that `--with /tmp/brief.txt` was ignored. The only two forms that ever worked:

```bash
--with skills=my-skill,another-skill   # injects SKILL.md contents into the prompt
--with mcp=server-name                 # loads named MCP servers into a strict config
```

## The fix

Added `_validate_with_token`, called at all three `--with` parse sites (`parse_model`, `_consume_flags`, fanout) so behavior is consistent everywhere. It rejects anything that isn't a recognized form, with a message that names the bad spec and points at the valid forms:

```
ERROR: --with requires e.g. skills=a,b or mcp=x (got '/tmp/brief.txt'); an unrecognized spec is rejected rather than silently dropped
```

The existing empty-argument `die` at each parse site is kept. This adds the non-empty-but-unrecognized `die` on top of it.

**Validation details** (hardened after review):

- **Every token is checked, not just the prefix.** `WITH_SPEC` is space-delimited and iterated unquoted at injection time, so `--with "skills=a,b /tmp/brief.txt"` splits into two tokens. Prefix-only validation would let the bare path through and it would silently drop at injection — the same footgun. The validator splits on whitespace and checks each token individually.
- **Empty values are rejected.** `skills=` and `mcp=` (no value after `=`) are silent no-ops of the same class, so they're rejected too (`skills=?*|mcp=?*`).
- **No file-attach feature is added.** This only stops the silent no-op. If file-attach is wanted later, it should be an explicit, documented form — not an accidental side effect of missing validation.

A comment was also added to the secret-scan's bare-file branch (`_secret_scan`), which is now unreachable after parse-time validation — every `WITH_SPEC` token is guaranteed to be a `skills=` or `mcp=` form, so the `*=*) continue` branch always fires. The dead branch is kept as defensive coverage in case a future code path sets `WITH_SPEC` without going through the validators.

## Tests

`test_with_injection.sh` gains 10 new cases covering:

- `skills=a,b` and `mcp=x` accepted (no regression to the two real forms)
- bare file path rejected
- unknown `form=` spec rejected
- rejection message names the spec and the valid forms
- empty `skills=` and `mcp=` rejected
- multi-token spec with all valid forms accepted (`"skills=a,b mcp=x"`)
- multi-token spec with an invalid trailing token rejected (`"skills=a,b /tmp/brief.txt"`)
- whitespace-smuggling rejection names the bad token, not just the prefix

```
$ bash tests/test_with_injection.sh
RESULT: 20 passed, 0 failed
```

The suite is already in `conformance.sh`'s static gate (`_ALL_SUITES`); no registration change needed.

#### Test plan
- [x] `bash tests/test_with_injection.sh` — 20/20 pass
- [x] `bash -n outsourcerer.sh` — syntax clean
- [x] `--with skills=…` / `--with mcp=…` still accepted (no regression)
- [x] `--with /tmp/brief.txt` now dies loudly instead of silently running without context
- [x] `--with "skills=a,b /tmp/brief.txt"` rejects the bad trailing token, not just the prefix
- [x] `--with skills=` / `--with mcp=` rejected (empty values are no-ops)
