### PR TITLE
fix(heartbeat): don't leak the election fd into the beacon, and don't kill a healthy beacon on a transient identity read

### DIFF
--- a/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
@@ -4491,8 +4491,13 @@ _heartbeat_start() {
     _heartbeat_election_release "$lock"
     return 1
   fi
+  # 8>&- : the caller still holds the election flock on fd 8. A backgrounded child inherits open
+  # fds, so without this the beacon would carry a duplicate of the election-lock fd for its whole
+  # life -- a stale handle that keeps the lock's open-file-description referenced and can briefly
+  # contend a concurrent re-election until the parent's own release. Close it in the child; the
+  # beacon opens its own election fd when it needs one.
   OSRC_HEARTBEAT_TOKEN="$token" OSRC_HEARTBEAT_SINK="$sink" \
-    nohup "$executable" __heartbeat-beacon "$token" >/dev/null 2>&1 &
+    nohup "$executable" __heartbeat-beacon "$token" 8>&- >/dev/null 2>&1 &
   child_pid=$!
   if ! _heartbeat_election_release "$lock"; then
     kill "$child_pid" 2>/dev/null || true
@@ -4509,7 +4514,13 @@ _heartbeat_start() {
       if [ -n "$owner_pid" ] && [ -n "$owner_start" ] && _pid_start_valid "$owner_start" && kill -0 "$owner_pid" 2>/dev/null; then
         live_start="$(_pid_start_identity "$owner_pid" 2>/dev/null)"
         live_rc=$?
-        if [ "$live_rc" -eq 0 ] && [ "$live_start" = "$owner_start" ]; then
+        # The owner pid is already proven live by the kill -0 above. Confirm it is really OUR beacon
+        # via the start-time identity when we can read it (the PID-reuse guard), but fall back to that
+        # liveness when the identity re-read is unsupported or fails -- exactly as _heartbeat_leader_alive
+        # does. The old check required live_rc == 0, so a transient/unsupported _pid_start_identity made
+        # the loop time out and kill a healthy, freshly-armed beacon. Only reject on a real mismatch:
+        # identity readable AND different (a genuinely reused pid).
+        if [ "$live_rc" -ne 0 ] || [ "$live_start" = "$owner_start" ]; then
           return 0
         fi
       fi


### PR DESCRIPTION
fix(heartbeat): don't leak the election fd into the beacon, and don't kill a healthy beacon on a transient identity read

**What**
Two independent robustness fixes in `_heartbeat_start`:

1. Close file descriptor 8 when spawning the background beacon.
2. Fall back to the liveness check already done when the start-time identity re-read is unavailable,
   instead of timing out and killing the beacon we just launched.

**Why it matters**
- **Inherited election fd.** The beacon is spawned with `nohup ... &` while the caller still holds
  the election `flock` on fd 8. A backgrounded child inherits open descriptors, so the beacon would
  carry a duplicate handle to the election lock for its entire life. The parent's own release still
  clears the lock (it unlocks before closing), so this is not a hard deadlock, but the stale
  inherited handle keeps the lock's open-file-description referenced and can briefly contend a
  concurrent re-election. The beacon never needs that descriptor; it opens its own when it elects.
- **Healthy beacon killed on a transient read.** The start-confirmation loop required
  `_pid_start_identity` on the owner pid to both succeed and match. But the owner pid was already
  proven alive by a `kill -0` immediately above, and the sibling `_heartbeat_leader_alive` already
  falls back to `kill -0` when the start-time identity is unsupported or fails. So on a platform or
  in a moment where `_pid_start_identity` returns non-zero, the loop never confirmed, ran to timeout,
  and then `kill`ed a beacon that had in fact started fine. Supervision would silently fail to arm.

**How it's fixed**
- Added `8>&-` to the `nohup` spawn so the child starts without the inherited election descriptor.
- Changed the confirmation to accept the owner when the identity re-read fails (leaning on the
  `kill -0` that already gated entry) OR when the start-times match. It now only *rejects* on a real
  mismatch, meaning the identity was readable and different, which is the genuine pid-reuse case the
  check is there to catch. This mirrors what `_heartbeat_leader_alive` already does.

**When it bites**
The fd leak is a quiet correctness/hygiene issue on every arm. The confirmation fix matters on any
host where `_pid_start_identity` is unsupported or flaky: before this change, arming the heartbeat
there fails intermittently and supervision goes dark with a generic "no valid live owner" message,
even though the beacon started. Hard to reproduce on demand because it rides a transient identity
read, which is exactly why it is worth removing.
