### PR TITLE
fix(model-denylist): keep `*` family patterns from globbing against the cwd

### DIFF
--- a/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
@@ -2505,10 +2505,21 @@ _quota_note_refusal() {  # <lane-or-disp> <model> [reset]
 # before dispatch (so nothing denied ever runs, whether picked by advise or pinned with -m). Absent
 # or empty OSRC_MODEL_DENYLIST is a no-op -- default behavior is completely unchanged.
 _model_denied() {
-  local id="$1" list="${OSRC_MODEL_DENYLIST:-}" pat
+  local id="$1" list="${OSRC_MODEL_DENYLIST:-}" pat _osrc_had_f=0
   [ -n "$list" ] || return 1
   local IFS=', '
-  for pat in $list; do
+  # A '*' family entry (e.g. gemini-3.5-*) must not undergo PATHNAME expansion while we split the
+  # unquoted list: in a cwd that happens to hold a matching file, the glob rewrites the pattern to
+  # that filename and the deny silently misses. Split once with globbing disabled, then restore the
+  # caller's glob state. `_osrc_had_f` records whether the caller ALREADY had `set -f`, so we only
+  # re-enable globbing (`set +f`) when the caller didn't. (The `case "$id" in $pat` match below is
+  # pattern matching, not filename expansion, so it keeps working regardless -- bracket ids stay
+  # literal as before.)
+  case "$-" in *f*) _osrc_had_f=1 ;; esac
+  set -f
+  set -- $list
+  [ "$_osrc_had_f" = 0 ] && set +f
+  for pat in "$@"; do
     # Exact match first, so a literal id containing glob metachars is honored as itself. Real model
     # ids carry brackets (e.g. claude-opus-4-8[1m]); an unquoted `case $id in $pat` reads `[1m]` as a
     # character class, which both fails to deny the id's own literal string AND over-matches unrelated


### PR DESCRIPTION
fix(model-denylist): keep `*` family patterns from globbing against the cwd

**What**
`_model_denied` splits `OSRC_MODEL_DENYLIST` with an unquoted `for pat in $list`. A documented
family entry like `gemini-3.5-*` therefore goes through pathname expansion during the split.

**Why it matters**
If the current directory happens to contain a file that matches the pattern, the glob rewrites the
entry to that filename before the comparison ever runs, and the deny silently misses. Since this is
a guard that decides whether a model is allowed to run, a silent miss is the bad kind: a model you
meant to block gets through, and nothing tells you. The existing code already thought about glob
metacharacters inside the `case "$id" in $pat` match (that is why bracket ids stay literal); the one
spot it missed is the word-split on `$list` itself.

**How it's fixed**
Split the list once with pathname expansion turned off: remember the caller's glob state, `set -f`,
`set -- $list`, then restore the prior state, and iterate the quoted positional params. The
`case "$id" in $pat` match below is pattern matching, not filename expansion, so it is unaffected and
bracket-bearing ids keep matching literally exactly as before. No behavior change for anyone whose
cwd doesn't happen to collide with a denylist pattern, which is the whole point.

**Repro**
```sh
mkdir /tmp/glob-demo && cd /tmp/glob-demo
touch 'gemini-3.5-oops'                 # a file that matches the family pattern
OSRC_MODEL_DENYLIST='gemini-3.5-*'
# ask the tool to route/pin gemini-3.5-flash from this directory
# before: the model is NOT denied (the pattern expanded to the filename)
# after:  the model is denied as intended
```
Run the same thing from an empty directory and it behaves correctly before and after, which is why
this went unnoticed.
