### PR TITLE
fix: keep OSRC_VERSION in sync with plugin.json

### DIFF
--- a/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
@@ -147,7 +147,7 @@ set -uo pipefail
 export PATH="$HOME/.local/bin:$PATH"
 # Version identifier. Single source of truth; bump the rightmost
 # number for patch releases. `doctor` and `--version` both read this.
-OSRC_VERSION="0.10.5"
+OSRC_VERSION="0.11.0"
 DEFAULT_MODEL="${OUTSOURCERER_MODEL:-glm-5.2}"
 
 # ---- platform detection (mac | linux | windows-gitbash). Windows = Git Bash / MSYS2, NO WSL

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/conformance.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/conformance.sh
@@ -90,6 +90,7 @@ _ALL_SUITES="$_ALL_SUITES test_preflight_guard_exempt"
 _ALL_SUITES="$_ALL_SUITES test_preflight_env_isolation"
 _ALL_SUITES="$_ALL_SUITES test_heartbeat_arm_liveness test_heartbeat_autoarm test_heartbeat_stale_alarm test_heartbeat_rearm_command"
 _ALL_SUITES="$_ALL_SUITES test_tier_churn"
+_ALL_SUITES="$_ALL_SUITES test_version_parity"
 for t in $_ALL_SUITES; do
   if [ -f "$SCRIPT_DIR/$t.sh" ]; then
     # Capture rather than discard: a failing suite whose output went to /dev/null makes a CI log say

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_version_parity.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_version_parity.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Guard against OSRC_VERSION drifting from plugin.json. The version literal in outsourcerer.sh and the
+# "version" in .claude-plugin/plugin.json are two hand-maintained copies; a release that bumps one and
+# not the other makes `doctor` report a drift and `--version` lie. This test fails when they diverge,
+# so the literal is kept in sync mechanically instead of by memory.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SRC="$HERE/../outsourcerer.sh"
+MF="$HERE/../../../../.claude-plugin/plugin.json"
+[ -f "$SRC" ] || { echo "FAIL: cannot find $SRC"; exit 1; }
+[ -f "$MF" ]  || { echo "FAIL: cannot find plugin.json at $MF"; exit 1; }
+
+pass=0; fail=0
+ok()  { echo "PASS: $1"; pass=$((pass + 1)); }
+bad() { echo "FAIL: $1"; fail=$((fail + 1)); }
+
+# Same grep-the-literal technique doctor already uses for its second-copy drift check.
+sv="$(grep -m1 '^OSRC_VERSION=' "$SRC" | cut -d'"' -f2)"
+pv="$(grep -m1 '"version"'      "$MF"  | cut -d'"' -f4)"
+
+[ -n "$sv" ] || bad "could not read OSRC_VERSION literal from $SRC"
+[ -n "$pv" ] || bad "could not read \"version\" from $MF"
+
+if [ -n "$sv" ] && [ "$sv" = "$pv" ]; then
+  ok "OSRC_VERSION literal ($sv) matches plugin.json ($pv)"
+elif [ -n "$sv" ]; then
+  bad "version drift: OSRC_VERSION literal is $sv but plugin.json is $pv — bump the literal in outsourcerer.sh"
+fi
+
+echo "== $pass passed, $fail failed =="
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What
The `OSRC_VERSION` literal in `outsourcerer.sh` is still `0.10.5` while `plugin.json` is `0.11.0`, so `--version` and `doctor` both report the wrong version. This bumps the literal and adds a test that keeps the two copies in sync.

## Why (repro)
`doctor` flags it directly:

```
== outsourcerer doctor (v0.10.5) ==
  version DRIFT: running script v0.10.5 but plugin.json says v0.11.0 - bump one to match.
```

The literal has been behind for at least two releases: it reads `0.10.5` in the cached 0.10.6 build, the cached 0.11.0 build, and on `main`. `plugin.json` gets bumped on release but the constant does not.

## How
- Bump `OSRC_VERSION` to `0.11.0`.
- Add `test_version_parity.sh` (registered in `_ALL_SUITES`): it greps the `^OSRC_VERSION=` literal from source and compares it to `plugin.json`, the same grep-the-literal technique `doctor` already uses for its second-copy drift check. It fails when they diverge, so the two copies can't silently drift again.

I kept the literal on purpose rather than deriving the version from `plugin.json` at runtime: deriving would make `doctor`'s own drift check tautological (it compares the running value to `plugin.json`). A pinned literal plus a test that enforces the match keeps the check meaningful.

## Test
```
bash plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_version_parity.sh
# PASS: OSRC_VERSION literal (0.11.0) matches plugin.json (0.11.0)
```
