### PR TITLE
feat(diagnostics): record sandboxed-proxy TLS failures as reason=proxy_tls

### DIFF
--- a/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
@@ -5431,7 +5431,7 @@ record_outcome() {
   esac
   # reason MUST be a fixed enum (never task text) — an unknown reason is dropped, not stored verbatim.
   case "$reason" in
-    ''|test_failure|compile_failure|invalid_output|empty-output|permission_denied|consent_denied|secret_scan|provider_error|timeout|watchdog|merge_conflict|user_cancelled|missing_tool) ;;
+    ''|test_failure|compile_failure|invalid_output|empty-output|permission_denied|consent_denied|secret_scan|provider_error|proxy_tls|timeout|watchdog|merge_conflict|user_cancelled|missing_tool) ;;
     *) reason="" ;;
   esac
   # repo_key MUST be a cksum (numeric) or the PII guarantee breaks; turns MUST be numeric or omitted.
@@ -8623,6 +8623,11 @@ run_job() {
   # `failed` was recorded only as generic provider_error and the actual empty-output failure
   # vanished as soon as the transient supervisor message scrolled away.
   [ "$(cat "$jd/reason" 2>/dev/null || true)" = "empty-output" ] && _rsn="empty-output"
+  # Refine the generic provider_error bucket for the sandboxed-proxy TLS reject: delegate() already
+  # wrote its recognizable hint sentence into THIS job's out.log, so a job-scoped grep (no cross-job
+  # misattribution) lets the ledger/advise tell an environment/proxy failure apart from a real
+  # provider failure. Only refines provider_error -- never overrides timeout/watchdog/etc.
+  [ "$_rsn" = "provider_error" ] && grep -q 'devin TLS handshake failed against a local proxy' "$jd/out.log" 2>/dev/null && _rsn="proxy_tls"
   # Pass EVERY field explicitly — no reliance on exported env (which record_ledger no longer sets).
   record_outcome "$_oc" "$_rsn" "" "$id" "$lane" "$id2" "${OSRC_TASK_CLASS:-}" "$(_repo_key)"
   return "$sc"

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_devin_tls_diagnostics.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_devin_tls_diagnostics.sh
@@ -200,6 +200,29 @@ if _is_transport_failure 'max-turns reached' 1; then bad "regression: max-turns 
 # retry trigger) — asserting this keeps the diagnostics-only contract honest.
 if _is_transport_failure "$rustls_fixture" 1; then bad "regression: rustls signature leaked into _is_transport_failure (would change retry behavior)"; else ok "regression: rustls signature stays out of _is_transport_failure"; fi
 
+# --- Scenario 5: the proxy_tls reason is a durable, stored reason (not dropped by the enum). ---
+# record_outcome whitelists reasons and blanks any unknown one; proxy_tls must survive so a
+# proxy-TLS failure is distinguishable from a real provider failure in the ledger.
+if have jq; then
+  record_outcome blocked proxy_tls "" "test-rid-ptls" dv glm-5.2 code 123 >/dev/null 2>&1
+  of="$(_outcomes_current 2>/dev/null)"
+  if [ -n "$of" ] && grep -q '"run_id":"test-rid-ptls"' "$of" 2>/dev/null && grep -q '"reason":"proxy_tls"' "$of" 2>/dev/null; then
+    ok "reason: proxy_tls stored durably by record_outcome (not blanked by the enum)"
+  else
+    bad "reason: proxy_tls was DROPPED by record_outcome (add it to the reason enum)"
+  fi
+else
+  echo "SKIP: reason enum durability (jq absent)"
+fi
+
+# --- Scenario 6: the outcome-time classifier is wired job-scoped (source cross-check). ---
+grep -qF 'provider_error|proxy_tls|timeout' "$SRC" && ok "source: reason enum whitelists proxy_tls" || bad "source: proxy_tls missing from reason enum"
+if grep -q 'devin TLS handshake failed against a local proxy' "$SRC" && grep -q '_rsn="proxy_tls"' "$SRC"; then
+  ok "source: outcome classifier sets proxy_tls from the job's own out.log"
+else
+  bad "source: proxy_tls outcome classifier not wired at outcome-recording time"
+fi
+
 echo
 echo "RESULT: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## What
Record a sandboxed-proxy TLS failure as `reason=proxy_tls` in the outcome ledger, instead of the generic `provider_error` it collapses to today.

## Why (repro)
When a local/sandboxed proxy is in the shell (`*_PROXY` set), devin's Rust TLS client rejects the proxy cert and surfaces a bare "Connection error". Outsourcerer already RECOGNIZES this (`_is_sandboxed_proxy_tls_failure` plus the `delegate()` hint), but only as a transient stderr hint. The durable outcome stays `provider_error`.

Running against a repo behind such a proxy for a week, this was the dominant failure, and it is indistinguishable in the ledger from a real provider failure:

```
137 delegations -> 129 blocked/provider_error, 0 verified.
$ outsourcerer doctor
  proxy: a *_PROXY env var is set in this shell - devin's Rust TLS client may reject the proxy
         cert (rustls OSStatus cert-verify error, surfaces as a bare 'Connection error' ...).
```

Because every one of them is bucketed as `provider_error`, `advise` and any triage can't tell an environment/proxy failure apart from real provider death.

## How
- Add `proxy_tls` to the `record_outcome` reason enum. This is the load-bearing line: the enum blanks any unknown reason, so without it the naive change records `blocked` with NO reason, which is worse than today.
- At outcome-recording time, refine `provider_error` -> `proxy_tls` when THIS job's own `out.log` carries the recognizable hint sentence `delegate()` already writes there. Job-scoped on purpose: the underlying detector reads devin's newest log, which with a concurrency cap of 2 could misattribute across jobs, so I grep the job's own `out.log` instead. It only refines `provider_error`, never overrides `timeout`/`watchdog`/etc.

The outcome stays `blocked` (no model-quality-learning poisoning); only the reason gets sharper. Diagnostics-only, no retry/routing change.

## Test
Extends `test_devin_tls_diagnostics.sh`: asserts `proxy_tls` survives `record_outcome` (the enum), and that the outcome classifier is wired at recording time. 48/48 green.
