### PR TITLE
feat(routing): lane-down marker primitives (foundation for skipping a known-down lane)

### DIFF
--- a/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
@@ -2654,6 +2654,38 @@ _quota_marker_active() {  # <lanekey> <model> -> rc0 if an unexpired marker exis
   [ "$cur" = "$v" ] && rm -f "$OSRC_POSTURE_DIR/$1.quota-$slug" 2>/dev/null
   return 1
 }
+
+# ---- LANE-DOWN marker (sibling of the quota exhausted-until marker) ----------------------------
+# A lane can be UNREACHABLE without being at-cap: the Devin free GLM probe times out, or a
+# sandboxed-proxy TLS reject makes the whole devin lane unusable. doctor already detects this, but
+# dispatch never consulted it, so a down default absorbed dozens of full-timeout dispatches before
+# falling through. This marker lets a dispatch-time gate skip a known-down LANE for a short,
+# self-healing window. Keyed by LANE (not model): a proxy/transport failure takes the whole lane
+# down, not one model. Strict direction only (forces skip, never forces "up"), mirroring the quota
+# marker's posture contract; expired markers self-purge value-matched. TTL is short so a transient
+# outage heals on its own with no manual reset (override via OSRC_LANE_DOWN_TTL, default 300s).
+_lane_down_mark() {  # <lane-or-disp> [ttl-secs]
+  local lane; lane="$(_quota_lane_key "$1")"
+  [ -n "$lane" ] && [ "$lane" != "?" ] || return 0
+  local ttl="${2:-${OSRC_LANE_DOWN_TTL:-300}}"
+  case "$ttl" in ''|*[!0-9]*) ttl=300 ;; esac
+  local until; until="$(( $(date +%s) + ttl ))"
+  _posture_set "$lane" "down" "$until"
+}
+_lane_down_active() {  # <lane-or-disp> -> rc0 if an unexpired down marker exists (self-purges)
+  local lane; lane="$(_quota_lane_key "$1")"
+  [ -n "$lane" ] && [ "$lane" != "?" ] || return 1
+  local v; v="$(_posture_get "$lane" "down" 2>/dev/null)" || return 1
+  case "$v" in ''|*[!0-9]*) return 1 ;; esac
+  local now; now="$(date +%s)"
+  if [ "$v" -gt "$now" ]; then return 0; fi
+  # Expired -> purge on read, VALUE-MATCHED (same hardening as _quota_marker_active): only delete if
+  # the file still holds the expired value we read, so a sibling's fresh marker in the race is kept.
+  local cur; cur="$(_posture_get "$lane" "down" 2>/dev/null)"
+  [ "$cur" = "$v" ] && rm -f "$OSRC_POSTURE_DIR/$lane.down" 2>/dev/null
+  return 1
+}
+
 # Mark <model> on <lane> exhausted until the next reset, from a REAL provider quota refusal. No-op
 # unless a cap is declared (the marker only reconciles a declared cap; cap-first _quota_gate would
 # ignore it otherwise, and writing one would just litter the posture dir). Reset zone follows the cap.

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/conformance.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/conformance.sh
@@ -90,6 +90,7 @@ _ALL_SUITES="$_ALL_SUITES test_preflight_guard_exempt"
 _ALL_SUITES="$_ALL_SUITES test_preflight_env_isolation"
 _ALL_SUITES="$_ALL_SUITES test_heartbeat_arm_liveness test_heartbeat_autoarm test_heartbeat_stale_alarm test_heartbeat_rearm_command"
 _ALL_SUITES="$_ALL_SUITES test_tier_churn"
+_ALL_SUITES="$_ALL_SUITES test_lane_down_marker"
 for t in $_ALL_SUITES; do
   if [ -f "$SCRIPT_DIR/$t.sh" ]; then
     # Capture rather than discard: a failing suite whose output went to /dev/null makes a CI log say

--- a/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_lane_down_marker.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/tests/test_lane_down_marker.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# test_lane_down_marker.sh — the LANE-DOWN posture marker primitives (_lane_down_mark /
+# _lane_down_active). Sibling of the quota exhausted-until marker; strict-direction, self-healing
+# TTL, keyed by LANE (not model), expired markers self-purge value-matched. These primitives are
+# inert until a dispatch gate consults them (see the PR's wiring proposal) — this test pins the
+# primitive contract so the wiring can be reviewed/added safely.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SRC="$SCRIPT_DIR/../outsourcerer.sh"
+[ -f "$SRC" ] || { echo "FAIL: cannot find $SRC"; exit 1; }
+bash -n "$SRC" || { echo "FAIL: bash -n failed for $SRC"; exit 1; }
+
+TMP="$(mktemp -d)"; export OSRC_HOME="$TMP"; export HOME="$TMP"
+cleanup() { rm -rf "$TMP"; }; trap cleanup EXIT
+. "$SRC" >/dev/null 2>&1
+
+pass=0; fail=0
+ok()  { echo "PASS: $1"; pass=$((pass + 1)); }
+bad() { echo "FAIL: $1"; fail=$((fail + 1)); }
+
+# Clean: no marker -> not down.
+if _lane_down_active dv; then bad "clean: dv reported down with no marker"; else ok "clean: dv not down initially"; fi
+
+# Mark down -> active within TTL.
+_lane_down_mark dv 300
+if _lane_down_active dv; then ok "marked: dv down within TTL"; else bad "marked: dv NOT down after mark"; fi
+
+# Lane keying: a dispatch/provider name folds to the same lane code as the marker.
+if _lane_down_active devin; then ok "keying: 'devin' folds to dv (same marker)"; else bad "keying: 'devin' did not match the dv marker"; fi
+
+# Isolation: a DIFFERENT lane is unaffected.
+if _lane_down_active or; then bad "isolation: 'or' falsely reported down"; else ok "isolation: 'or' unaffected by the dv marker"; fi
+
+# Strict direction: an already-expired marker is NOT active and is purged on read.
+_posture_set cx down 1   # epoch 1 (1970) -> long expired
+if _lane_down_active cx; then bad "expired: cx still reported down"; else ok "expired: cx not active"; fi
+if [ -e "$OSRC_POSTURE_DIR/cx.down" ]; then bad "expired: marker file not purged on read"; else ok "expired: marker file purged on read"; fi
+
+# Junk value never reads as down (hardening: non-numeric posture value).
+_posture_set gm down "not-a-number"
+if _lane_down_active gm; then bad "junk: non-numeric marker read as down"; else ok "junk: non-numeric marker ignored"; fi
+
+echo "== $pass passed, $fail failed =="
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
> DRAFT / proposal. The marker primitives are committed and tested; the dispatch WIRING is written up below rather than committed, because it needs your eye on gate order and I couldn't integration-test the fallthrough. Depends conceptually on the `proxy_tls` classification PR.

## What
`doctor` detects when a free lane is unreachable (the Devin GLM probe times out, or a sandboxed-proxy TLS reject makes the whole devin lane unusable), but dispatch never consulted that. A down default absorbed dozens of full-timeout dispatches before falling through.

## Why (repro)
```
$ outsourcerer doctor
  Devin GLM (free): GENUINELY DOWN - glm-5-2 probe timed out after 30s ...
  default model: glm-5.2

# same week, delegation outcomes:
68 devin dispatches -> blocked/provider_error   (the down default, hammered)
```

The router already skips an AT-CAP model before dispatch (the per-model quota gate), but a lane that is DOWN (not quota-capped) has no equivalent pre-dispatch skip.

## How (this PR: primitives only)
Adds the marker primitives, as a sibling of the quota exhausted-until marker, reusing the same posture infrastructure:

- `_lane_down_mark <lane> [ttl]` writes a short, self-healing down marker
- `_lane_down_active <lane>` returns 0 if an unexpired marker exists (self-purges, value-matched)

Keyed by LANE, not model (a proxy/transport failure takes the whole lane down). Strict direction only (forces skip, never "up"), mirroring the quota marker's posture contract. Short TTL so a transient outage heals with no manual reset (`OSRC_LANE_DOWN_TTL`, default 300s). `test_lane_down_marker.sh` covers set/active/keying/isolation/expiry+purge/junk (7/7). The primitives are inert until a gate consults them, so this commit is a no-op on dispatch behavior.

## Proposed wiring (for your review, not committed)
1. READ: a SEPARATE, UNCONDITIONAL `_lane_down_active` check AHEAD of the quota block. The quota gate returns "go" before any marker check when no cap is declared, and the Devin free default has no cap, so a check placed inside the quota path would never fire. On a hit, skip the lane and fall through to the next free candidate (a pinned `-m` refuses loudly with the down reason and retry-after, matching the at-cap disclosure contract).
2. WRITE: mark the lane down on the free-probe timeout and on the `proxy_tls` reason (from the classification PR). I'd avoid using "empty-output" as a trigger since that is already a distinct model-level reason and would take a live lane out for the TTL.

@alexgreensh I didn't want to change dispatch behavior without being able to integration-test the fallthrough across live lanes. If you're happy with the gate placement, I'll wire it and add a dispatch-level test.
