### PR TITLE
tap: resolve newest version at render time so the statusline survives plugin updates

### DIFF
--- a/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
+++ b/plugins/outsourcerer/skills/outsourcerer/scripts/outsourcerer.sh
@@ -6162,6 +6162,30 @@ _tap_statusline_cmd() {
     [ -f "$cmd" ] && { printf '%s tap run' "$cmd"; return; }
     printf 'bash "%s" tap run' "$SCRIPT_PATH"; return   # fallback: explicit bash
   fi
+  # If we are running from a versioned plugin-cache path, emit a command that
+  # resolves the NEWEST installed version at render time instead of hard-pinning
+  # this version's path. A plugin update installs a new version dir and later
+  # prunes the old one; a hard-pinned path then vanishes and the statusline goes
+  # blank with no error. Resolving at render time survives every future update.
+  # Falls back to the current path if nothing resolves.
+  case "$SCRIPT_PATH" in
+    */plugins/cache/*/*/*/skills/outsourcerer/scripts/outsourcerer.sh)
+      local vroot
+      vroot=$(cd "$(dirname "$SCRIPT_PATH")/../../../.." 2>/dev/null && pwd) || vroot=""
+      # Emit the resolver only when the anchor resolved AND both paths are free of
+      # characters that would break (or inject into) the single-quoted `sh -c`
+      # payload. Plugin-cache paths never contain these in practice; if they ever
+      # do, fall through to the plain pinned command below. `sort -V` sorts on the
+      # version component because every glob match shares the same directory prefix.
+      case "$vroot::$SCRIPT_PATH" in
+        ::*|*[\'\"\$\`\\]*) ;;
+        *)
+          printf 'sh -c '\''s=$(ls -d "%s"/*/skills/outsourcerer/scripts/outsourcerer.sh 2>/dev/null | sort -V | tail -1); exec "${s:-%s}" tap run'\''' "$vroot" "$SCRIPT_PATH"
+          return
+          ;;
+      esac
+      ;;
+  esac
   printf '%s tap run' "$SCRIPT_PATH"
 }
 # =============================================================================


### PR DESCRIPTION
Hi Alex, small fix for a papercut in `tap install`.

## What
`_tap_statusline_cmd` writes the statusLine command using `$SCRIPT_PATH`, which is the fully versioned plugin-cache path (for example `.../plugins/cache/outsourcerer/outsourcerer/0.11.0/skills/outsourcerer/scripts/outsourcerer.sh`). That exact path gets baked into `~/.claude/settings.json`.

## Why it bites
Every plugin update installs a new version directory and eventually prunes the old one. `tap install` does not re-run on update, so settings keeps pointing at whatever version was live at install time. The day that version directory is pruned, the path no longer exists, the statusLine command fails to launch, and the statusline silently goes blank with no error. It looks like the tap broke at random, when really the pinned path just aged out. I hit this after an update left me pinned to a version that later got cleaned up.

## How this fixes it
When the running script sits under a versioned plugin-cache path, `_tap_statusline_cmd` now emits a command that resolves the newest installed version at render time instead of pinning the current one. It derives the version-independent anchor from `$SCRIPT_PATH` (the plugin directory that holds all version subdirs), globs for the newest `outsourcerer.sh` via `sort -V`, and execs that. Dev or non-cache installs keep the existing `printf '%s tap run' "$SCRIPT_PATH"` path unchanged.

Emitted command shape:
```
sh -c 's=$(ls -d "<plugin-dir>"/*/skills/outsourcerer/scripts/outsourcerer.sh 2>/dev/null | sort -V | tail -1); exec "${s:-<current-path>}" tap run'
```

If nothing resolves it falls back to the current pinned path, so the worst case is today's behavior. The resolver is also only emitted when both paths are free of quote, `$`, backtick, and backslash characters that could break or inject into the `sh -c` string, so it never writes a malformed or unsafe command.

## Scope and notes
- POSIX shell, with GNU/BSD `sort -V` for version ordering (present on macOS and Git Bash). The Windows branch (cmd launcher) still pins the current path. I left it alone rather than write a cmd.exe resolver blind, but happy to follow up if you want Windows covered the same way.
- During an update the resolver could briefly point at a version dir that is still being written or half-pruned. Worst case is a single blank statusline refresh, then it self-corrects. The pinned path avoids that only until it vanishes entirely, at which point it fails for good.
- `tap uninstall` still restores the stashed original, so this only changes what a fresh `tap install` writes and what an existing tap resolves to at runtime.

## Testing
- Verified the emitted command is valid shell and resolves to the newest installed version.
- Confirmed the fallback path is used when the glob finds nothing.
